### PR TITLE
TriangleRef --> PrimitiveRef and lean-out the representation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ src/geometry/closest.cpp
 src/error.cpp
 src/mesh_manager_interface.cpp
 src/ray_tracing_interface.cpp
-src/triangle_ref.cpp
+src/triangle_intersect.cpp
 src/util/str_utils.cpp
 src/xdg.cpp
 )

--- a/include/xdg/geometry_data.h
+++ b/include/xdg/geometry_data.h
@@ -7,12 +7,12 @@ namespace xdg
 {
 
 struct MeshManager; // Forward declaration
-struct TriangleRef; // Forward declaration
+struct PrimitiveRef; // Forward declaration
 
 struct GeometryUserData {
   MeshID surface_id {ID_NONE}; //! ID of the surface this geometry data is associated with
   MeshManager* mesh_manager {nullptr}; //! Pointer to the mesh manager for this geometry
-  TriangleRef* tri_ref_buffer {nullptr}; //! Pointer to the triangles in the geometry
+  PrimitiveRef* prim_ref_buffer {nullptr}; //! Pointer to the mesh primitives in the geometry
   double box_bump; //! Bump distance for the bounding boxes in this geometry
 };
 

--- a/include/xdg/geometry_data.h
+++ b/include/xdg/geometry_data.h
@@ -1,6 +1,8 @@
 #ifndef _XDG_GEOMETRY_DATA_H
 #define _XDG_GEOMETRY_DATA_H
 
+#include "xdg/constants.h"
+
 namespace xdg
 {
 
@@ -8,6 +10,7 @@ struct MeshManager; // Forward declaration
 struct TriangleRef; // Forward declaration
 
 struct GeometryUserData {
+  MeshID surface_id {ID_NONE}; //! ID of the surface this geometry data is associated with
   MeshManager* mesh_manager {nullptr}; //! Pointer to the mesh manager for this geometry
   TriangleRef* tri_ref_buffer {nullptr}; //! Pointer to the triangles in the geometry
   double box_bump; //! Bump distance for the bounding boxes in this geometry

--- a/include/xdg/primitive_ref.h
+++ b/include/xdg/primitive_ref.h
@@ -7,11 +7,8 @@
 
 namespace xdg {
 
-struct TriangleRef; // Forward declaration
-
-// TODO: could be a more generic primitive ref?
-struct TriangleRef {
-  MeshID triangle_id {ID_NONE};
+struct PrimitiveRef {
+  MeshID primitive_id {ID_NONE};
   Sense sense {Sense::UNSET};
 };
 

--- a/include/xdg/ray.h
+++ b/include/xdg/ray.h
@@ -89,7 +89,7 @@ struct RTCDHit : RTCHit {
   }
 
   // data members
-  const TriangleRef* tri_ref {nullptr}; //!< Pointer to the triangle reference for this hit
+  const PrimitiveRef* primitive_ref {nullptr}; //!< Pointer to the primitive reference for this hit
   Vec3da dNg; //!< Double precision version of the primitive normal
 };
 
@@ -133,7 +133,7 @@ struct RTCDPointQuery : RTCPointQuery {
   unsigned int primID = RTC_INVALID_GEOMETRY_ID; //<! ID of the nearest primitive
   unsigned int geomID = RTC_INVALID_GEOMETRY_ID; //<! ID of the nearest geometry
   double dblx, dbly, dblz; //<! Double precision version of the query location
-  const TriangleRef* tri_ref {nullptr}; //!< Pointer to the triangle reference for this hit
+  const PrimitiveRef* primitive_ref {nullptr}; //!< Pointer to the primitive reference for this hit
   double dradius; //!< Double precision version of the query distance
 };
 

--- a/include/xdg/ray_tracing_interface.h
+++ b/include/xdg/ray_tracing_interface.h
@@ -8,7 +8,7 @@
 #include "xdg/constants.h"
 #include "xdg/embree_interface.h"
 #include "xdg/mesh_manager_interface.h"
-#include "xdg/triangle_ref.h"
+#include "xdg/primitive_ref.h"
 #include "xdg/geometry_data.h"
 
 namespace xdg
@@ -50,7 +50,7 @@ public:
   void closest(MeshID volume,
                const Position& origin,
                double& dist,
-               TriangleRef& triangle);
+               PrimitiveRef& triangle);
 
   void closest(MeshID volume,
                const Position& origin,
@@ -87,7 +87,7 @@ private:
   double numerical_precision_ {1e-3};
 
   // storage
-  std::unordered_map<MeshID, std::vector<TriangleRef>> triangle_storage_map_;
+  std::unordered_map<MeshID, std::vector<PrimitiveRef>> primitive_ref_storage_;
 };
 
 } // namespace xdg

--- a/include/xdg/ray_tracing_interface.h
+++ b/include/xdg/ray_tracing_interface.h
@@ -50,7 +50,7 @@ public:
   void closest(MeshID volume,
                const Position& origin,
                double& dist,
-               PrimitiveRef& triangle);
+               MeshID& triangle);
 
   void closest(MeshID volume,
                const Position& origin,

--- a/include/xdg/ray_tracing_interface.h
+++ b/include/xdg/ray_tracing_interface.h
@@ -14,6 +14,8 @@
 namespace xdg
 {
 
+using TreeID = RTCScene;
+
 class RayTracer {
 // Constructors
 public:

--- a/include/xdg/triangle_ref.h
+++ b/include/xdg/triangle_ref.h
@@ -12,7 +12,6 @@ struct TriangleRef; // Forward declaration
 // TODO: could be a more generic primitive ref?
 struct TriangleRef {
   MeshID triangle_id {ID_NONE};
-  MeshID surface_id {ID_NONE};
   Sense sense {Sense::UNSET};
 };
 

--- a/include/xdg/xdg.h
+++ b/include/xdg/xdg.h
@@ -23,6 +23,10 @@ public:
     ray_tracing_interface_->register_all_volumes(mesh_manager_);
   }
 
+// Geometric Queries
+MeshID find_volume(const Position& point,
+                   const Direction& direction) const;
+
   // Geometric Measurements
   double measure_volume(MeshID volume) const;
   double measure_surface_area(MeshID surface) const;
@@ -34,8 +38,8 @@ public:
   }
 
 // Accessors
-  const RayTracer* ray_tracing_interface() const {
-    return ray_tracing_interface_.get();
+  const std::shared_ptr<RayTracer> ray_tracing_interface() const {
+    return ray_tracing_interface_;
   }
 
   const MeshManager* mesh_manager() const {
@@ -44,8 +48,8 @@ public:
 
 // Private methods
 private:
-  double _triangle_volume_contribution(const TriangleRef& triangle) const;
-  double _triangle_area_contribution(const TriangleRef& triangle) const;
+  double _triangle_volume_contribution(const PrimitiveRef& triangle) const;
+  double _triangle_area_contribution(const PrimitiveRef& triangle) const;
 
 private:
   const std::shared_ptr<RayTracer> ray_tracing_interface_ {std::make_shared<RayTracer>()};

--- a/src/ray_tracing_interface.cpp
+++ b/src/ray_tracing_interface.cpp
@@ -175,7 +175,7 @@ RayTracer::ray_fire(MeshID volume,
 void RayTracer::closest(MeshID volume,
                         const Position& point,
                         double& distance,
-                        PrimitiveRef& triangle_ref)
+                        MeshID& triangle)
 {
   RTCScene scene = volume_to_scene_map_[volume];
 
@@ -193,15 +193,15 @@ void RayTracer::closest(MeshID volume,
   }
 
   distance = query.dradius;
-  triangle_ref = *query.primitive_ref;
+  triangle = query.primitive_ref->primitive_id;
 }
 
 void RayTracer::closest(MeshID volume,
                         const Position& point,
                         double& distance)
 {
-  PrimitiveRef triangle_ref;
-  closest(volume, point, distance, triangle_ref);
+  MeshID triangle;
+  closest(volume, point, distance, triangle);
 }
 
 bool RayTracer::occluded(MeshID volume,
@@ -252,14 +252,12 @@ Direction RayTracer::get_normal(MeshID surface,
     point_query.set_point(point);
     point_query.set_radius(INFTY);
 
-    PrimitiveRef primitive_ref;
-    closest(surface_vols.first, point, dist, primitive_ref);
+    closest(surface_vols.first, point, dist, element);
 
     // TODO: bring this back when we have a better way to handle this
     // if (geom_data.surface_id != surface) {
     //   fatal_error("Point {} was closest to surface {}, not surface {}, in volume {}.", point, geom_data.surface_id, surface, surface_vols.first);
     // }
-    element = primitive_ref.primitive_id;
   }
 
   // return the normal of the selected triangle

--- a/src/ray_tracing_interface.cpp
+++ b/src/ray_tracing_interface.cpp
@@ -2,7 +2,7 @@
 #include "xdg/geometry_data.h"
 #include "xdg/ray_tracing_interface.h"
 #include "xdg/ray.h"
-#include "xdg/triangle_ref.h"
+#include "xdg/primitive_ref.h"
 
 namespace xdg {
 
@@ -34,8 +34,8 @@ RayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
 {
   // allocate storage for this volume
   auto volume_elements = mesh_manager->get_volume_elements(volume_id);
-  this->triangle_storage_map_[volume_id].resize(volume_elements.size());
-  auto& triangle_storage = this->triangle_storage_map_[volume_id];
+  this->primitive_ref_storage_[volume_id].resize(volume_elements.size());
+  auto& triangle_storage = this->primitive_ref_storage_[volume_id];
 
   auto volume_surfaces = mesh_manager->get_volume_surfaces(volume_id);
   int storage_offset {0};
@@ -49,9 +49,9 @@ RayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
 
     auto surface_elements = mesh_manager->get_surface_elements(surface_id);
     for (int i = 0; i < surface_elements.size(); ++i) {
-      auto& triangle_ref = triangle_storage[i + storage_offset];
-      triangle_ref.triangle_id = surface_elements[i];
-      triangle_ref.sense = triangle_sense;
+      auto& primitive_ref = triangle_storage[i + storage_offset];
+      primitive_ref.primitive_id = surface_elements[i];
+      primitive_ref.sense = triangle_sense;
     }
     storage_offset += surface_elements.size();
  }
@@ -61,7 +61,7 @@ RayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
   rtcSetSceneBuildQuality(volume_scene, RTC_BUILD_QUALITY_HIGH);
   this->volume_to_scene_map_[volume_id] = volume_scene;
 
-  TriangleRef* tri_ref_ptr = triangle_storage.data();
+  PrimitiveRef* tri_ref_ptr = triangle_storage.data();
 
   // compute the bounding box of the volume
   auto volume_bounding_box = mesh_manager->volume_bounding_box(volume_id);
@@ -87,13 +87,13 @@ RayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
     GeometryUserData surface_data;
     surface_data.surface_id = surface;
     surface_data.mesh_manager = mesh_manager.get();
-    surface_data.tri_ref_buffer = tri_ref_ptr + buffer_start;
+    surface_data.prim_ref_buffer = tri_ref_ptr + buffer_start;
     user_data_map_[surface_geometry] = surface_data;
 
     rtcSetGeometryUserData(surface_geometry, &user_data_map_[surface_geometry]);
 
     for (int i = 0; i < surface_triangles.size(); ++i) {
-      auto& triangle_ref = surface_data.tri_ref_buffer[i];
+      auto& triangle_ref = surface_data.prim_ref_buffer[i];
       // triangle_ref.embree_surface = embree_surface;
     }
     buffer_start += surface_triangles.size();
@@ -175,7 +175,7 @@ RayTracer::ray_fire(MeshID volume,
 void RayTracer::closest(MeshID volume,
                         const Position& point,
                         double& distance,
-                        TriangleRef& triangle_ref)
+                        PrimitiveRef& triangle_ref)
 {
   RTCScene scene = volume_to_scene_map_[volume];
 
@@ -193,14 +193,14 @@ void RayTracer::closest(MeshID volume,
   }
 
   distance = query.dradius;
-  triangle_ref = *query.tri_ref;
+  triangle_ref = *query.primitive_ref;
 }
 
 void RayTracer::closest(MeshID volume,
                         const Position& point,
                         double& distance)
 {
-  TriangleRef triangle_ref;
+  PrimitiveRef triangle_ref;
   closest(volume, point, distance, triangle_ref);
 }
 
@@ -252,14 +252,14 @@ Direction RayTracer::get_normal(MeshID surface,
     point_query.set_point(point);
     point_query.set_radius(INFTY);
 
-    TriangleRef triangle_ref;
-    closest(surface_vols.first, point, dist, triangle_ref);
+    PrimitiveRef primitive_ref;
+    closest(surface_vols.first, point, dist, primitive_ref);
 
     // TODO: bring this back when we have a better way to handle this
     // if (geom_data.surface_id != surface) {
     //   fatal_error("Point {} was closest to surface {}, not surface {}, in volume {}.", point, geom_data.surface_id, surface, surface_vols.first);
     // }
-    element = triangle_ref.triangle_id;
+    element = primitive_ref.primitive_id;
   }
 
   // return the normal of the selected triangle

--- a/src/ray_tracing_interface.cpp
+++ b/src/ray_tracing_interface.cpp
@@ -51,7 +51,6 @@ RayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
     for (int i = 0; i < surface_elements.size(); ++i) {
       auto& triangle_ref = triangle_storage[i + storage_offset];
       triangle_ref.triangle_id = surface_elements[i];
-      triangle_ref.surface_id = surface_id;
       triangle_ref.sense = triangle_sense;
     }
     storage_offset += surface_elements.size();
@@ -86,6 +85,7 @@ RayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
     this->surface_to_geometry_map_[surface] = surface_geometry;
 
     GeometryUserData surface_data;
+    surface_data.surface_id = surface;
     surface_data.mesh_manager = mesh_manager.get();
     surface_data.tri_ref_buffer = tri_ref_ptr + buffer_start;
     user_data_map_[surface_geometry] = surface_data;
@@ -255,9 +255,10 @@ Direction RayTracer::get_normal(MeshID surface,
     TriangleRef triangle_ref;
     closest(surface_vols.first, point, dist, triangle_ref);
 
-    if (triangle_ref.surface_id != surface) {
-      fatal_error("Point {} was closest to surface {}, not surface {}, in volume {}.", point, triangle_ref.surface_id, surface, surface_vols.first);
-    }
+    // TODO: bring this back when we have a better way to handle this
+    // if (geom_data.surface_id != surface) {
+    //   fatal_error("Point {} was closest to surface {}, not surface {}, in volume {}.", point, geom_data.surface_id, surface, surface_vols.first);
+    // }
     element = triangle_ref.triangle_id;
   }
 

--- a/src/xdg.cpp
+++ b/src/xdg.cpp
@@ -6,6 +6,18 @@
 #include "xdg/geometry/measure.h"
 namespace xdg {
 
+MeshID XDG::find_volume(const Position& point,
+                                                   const Direction& direction) const
+{
+  for (auto volume : mesh_manager()->volumes()) {
+    if (ray_tracing_interface()->point_in_volume(volume, point, &direction)) {
+      return volume;
+    }
+  }
+  return ID_NONE;
+}
+
+
 double XDG::measure_volume(MeshID volume) const
 {
   double volume_total {0.0};

--- a/tests/test_normal.cpp
+++ b/tests/test_normal.cpp
@@ -5,7 +5,7 @@
 // xdg includes
 #include "xdg/mesh_manager_interface.h"
 #include "xdg/ray_tracing_interface.h"
-#include "xdg/triangle_ref.h"
+#include "xdg/primitive_ref.h"
 
 #include "mesh_mock.h"
 

--- a/tests/test_normal.cpp
+++ b/tests/test_normal.cpp
@@ -27,20 +27,20 @@ TEST_CASE("Test Get Normal")
 
   // move the point closer to the positive x surface
   origin = {4.0, 0.0, 0.0};
-  TriangleRef triangle_ref;
-  rti->closest(volume, origin, nearest_distance, triangle_ref);
+  PrimitiveRef primitive_ref;
+  rti->closest(volume, origin, nearest_distance, primitive_ref);
   REQUIRE_THAT(nearest_distance, Catch::Matchers::WithinAbs(1.0, 1e-6));
 
   MeshID surface {mm->surfaces()[3]};
 
   // call for the normal w/o a triangle, it should be the same as the returned triangle from the closest call
   Direction normal = rti->get_normal(surface, origin);
-  REQUIRE(normal == mm->triangle_normal(triangle_ref.triangle_id));
+  REQUIRE(normal == mm->triangle_normal(primitive_ref.primitive_id));
 
   // move the origin, but pass the triangle
   // This should result in the same normal as well b/c the triangle is used intead of a call to 'closest'
   origin = {-2.0, 0.0, 0.0};
-  std::vector<MeshID> exclude_primitives {triangle_ref.triangle_id};
+  std::vector<MeshID> exclude_primitives {primitive_ref.primitive_id};
   normal = rti->get_normal(surface, origin, &exclude_primitives);
-  REQUIRE(normal == mm->triangle_normal(triangle_ref.triangle_id));
+  REQUIRE(normal == mm->triangle_normal(primitive_ref.primitive_id));
 }

--- a/tests/test_normal.cpp
+++ b/tests/test_normal.cpp
@@ -27,20 +27,20 @@ TEST_CASE("Test Get Normal")
 
   // move the point closer to the positive x surface
   origin = {4.0, 0.0, 0.0};
-  PrimitiveRef primitive_ref;
-  rti->closest(volume, origin, nearest_distance, primitive_ref);
+  MeshID triangle;
+  rti->closest(volume, origin, nearest_distance, triangle);
   REQUIRE_THAT(nearest_distance, Catch::Matchers::WithinAbs(1.0, 1e-6));
 
   MeshID surface {mm->surfaces()[3]};
 
   // call for the normal w/o a triangle, it should be the same as the returned triangle from the closest call
   Direction normal = rti->get_normal(surface, origin);
-  REQUIRE(normal == mm->triangle_normal(primitive_ref.primitive_id));
+  REQUIRE(normal == mm->triangle_normal(triangle));
 
   // move the origin, but pass the triangle
   // This should result in the same normal as well b/c the triangle is used intead of a call to 'closest'
   origin = {-2.0, 0.0, 0.0};
-  std::vector<MeshID> exclude_primitives {primitive_ref.primitive_id};
+  std::vector<MeshID> exclude_primitives {triangle};
   normal = rti->get_normal(surface, origin, &exclude_primitives);
-  REQUIRE(normal == mm->triangle_normal(primitive_ref.primitive_id));
+  REQUIRE(normal == mm->triangle_normal(triangle));
 }


### PR DESCRIPTION
The triangle reference (now primitive reference) doesn't need to hold the surface ID. That can be stored on the `GeometryUserData` object instead. This makes the reference that much smaller.