### PR TITLE
Bounding box fix

### DIFF
--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -186,8 +186,8 @@ MOABMeshManager::get_surface_elements(MeshID surface) const
 std::vector<Vertex> MOABMeshManager::element_vertices(MeshID element) const
 {
   moab::EntityHandle element_handle;
-  moab::ErrorCode rval = this->moab_interface()->handle_from_id(moab::MBTRI, element, element_handle);
-  if (rval == moab::MB_ENTITY_NOT_FOUND) fatal_error("Could not find entity with ID in the mesh database {}", element);
+  this->moab_interface()->handle_from_id(moab::MBTRI, element, element_handle);
+  // if (rval == moab::MB_ENTITY_NOT_FOUND) fatal_error("Could not find entity with ID in the mesh database {}", element);
   auto out = this->mb_direct()->get_mb_coords(element_handle);
   return std::vector<Vertex>(out.begin(), out.end());
 }

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -186,7 +186,8 @@ MOABMeshManager::get_surface_elements(MeshID surface) const
 std::vector<Vertex> MOABMeshManager::element_vertices(MeshID element) const
 {
   moab::EntityHandle element_handle;
-  this->moab_interface()->handle_from_id(moab::MBTRI, element, element_handle);
+  moab::ErrorCode rval = this->moab_interface()->handle_from_id(moab::MBTRI, element, element_handle);
+  if (rval == moab::MB_ENTITY_NOT_FOUND) fatal_error("Could not find entity with ID in the mesh database {}", element);
   auto out = this->mb_direct()->get_mb_coords(element_handle);
   return std::vector<Vertex>(out.begin(), out.end());
 }
@@ -206,11 +207,7 @@ Direction MOABMeshManager::triangle_normal(MeshID element) const
 BoundingBox MOABMeshManager::element_bounding_box(MeshID element) const
 {
   auto vertices = this->element_vertices(element);
-  BoundingBox bb;
-  for (const auto& v : vertices) {
-    bb.update(v);
-  }
-  return bb;
+  return BoundingBox::from_points(vertices);
 }
 
 BoundingBox

--- a/tools/particle_sim.cpp
+++ b/tools/particle_sim.cpp
@@ -141,30 +141,31 @@ const int n_particles {100};
 
 const int max_events {1000};
 
-bool verbose = true;
+bool verbose = false;
 
- for (int i = 0; i < n_particles; i++) {
- write_message("Starting particle {}", i);
- Particle p(xdg, i, verbose);
- p.initialize();
- while (true) {
-   p.surf_dist();
-   // terminate for leakage
-   if (!p.alive_) break;
-   p.sample_collision_distance();
-   p.advance();
-   if (p.surface_intersection_.first < p.collision_distance_)
-     p.cross_surface();
-   else
-     p.collide();
-   if (!p.alive_) break;
+for (int i = 0; i < n_particles; i++) {
+  int particle_id = i+1;
+  write_message("Starting particle {}", particle_id);
+  Particle p(xdg, particle_id, verbose);
+  p.initialize();
+  while (true) {
+    p.surf_dist();
+    // terminate for leakage
+    if (!p.alive_) break;
+    p.sample_collision_distance();
+    p.advance();
+    if (p.surface_intersection_.first < p.collision_distance_)
+      p.cross_surface();
+    else
+      p.collide();
+    if (!p.alive_) break;
 
-   if (p.n_events_ > max_events) {
-     write_message("Maximum number of events ({}) reached", max_events);
-     break;
-   }
- }
- }
+    if (p.n_events_ > max_events) {
+      write_message("Maximum number of events ({}) reached", max_events);
+      break;
+    }
+  }
+}
 
- return 0;
+return 0;
 }


### PR DESCRIPTION
The `MeshManager::element_bounding_box` method was exhibiting incorrect behavior because the starting bounding box was volume zero centered on the origin. 