### PR TITLE
More tools w/ arguments

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "fmt"]
 	path = vendor/fmt
 	url = https://github.com/fmtlib/fmt.git
+[submodule "vendor/argparse"]
+	path = vendor/argparse
+	url = https://github.com/p-ranav/argparse.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ if (NOT fmt_FOUND)
   add_subdirectory(vendor/fmt)
 endif()
 
+# argparse
+add_subdirectory(vendor/argparse)
+
 list(APPEND xdg_sources
 src/geometry/measure.cpp
 src/geometry/plucker.cpp

--- a/include/xdg/vec3da.h
+++ b/include/xdg/vec3da.h
@@ -2,20 +2,20 @@
 #ifndef _XDG_VEC3DA_H
 #define _XDG_VEC3DA_H
 
+#include <array>
 #include <assert.h>
 #include <iostream>
 #include <math.h>
 #include <immintrin.h>
 #include <xmmintrin.h>
 #include <limits>
+#include <vector>
 
 #ifndef NDEBUG
 #define __forceinline inline
 #else
 #define __forceinline inline __attribute__((always_inline))
 #endif
-
-#include <array>
 
 #include "xdg/constants.h"
 
@@ -29,6 +29,11 @@ struct Vec3da {
 #endif
     struct{ double x,y,z;  size_t a;};
   };
+
+  __forceinline Vec3da(std::vector<double> const& vec) : x(vec[0]), y(vec[1]), z(vec[2]), a(0) {
+    if (vec.size() != 3)
+      throw std::runtime_error("Vec3da constructor from std::vector<double> requires a vector of size 3");
+  }
 
   __forceinline Vec3da(std::array<double, 3> const& arr) : x(arr[0]), y(arr[1]), z(arr[2]), a(0) { }
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(TOOL_NAMES
 particle_sim
 ray_fire
+find_volume
 )
 
 foreach(tool ${TOOL_NAMES})

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TOOL_NAMES
 particle_sim
 ray_fire
 find_volume
+point_in_volume
 )
 
 foreach(tool ${TOOL_NAMES})

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,13 @@
 
 
-add_executable(particle-sim particle_sim.cpp)
-target_link_libraries(particle-sim xdg)
+
+set(TOOL_NAMES
+particle_sim
+ray_fire
+)
+
+foreach(tool ${TOOL_NAMES})
+    string(REPLACE "_" "-" tool_exec ${tool})
+    add_executable(${tool_exec} ${tool}.cpp)
+    target_link_libraries(${tool_exec} xdg argparse)
+endforeach()

--- a/tools/find_volume.cpp
+++ b/tools/find_volume.cpp
@@ -15,22 +15,19 @@ using namespace xdg;
 
 int main(int argc, char** argv) {
 
-  argparse::ArgumentParser args("XDG Ray Fire Tool", "1.0", argparse::default_arguments::help);
+  argparse::ArgumentParser args("XDG Find Volume Tool", "1.0", argparse::default_arguments::help);
 
   args.add_argument("filename")
     .help("Path to the input file");
-
-  args.add_argument("volume")
-    .help("Volume ID to query").scan<'i', int>();
 
   args.add_argument("-l", "--list")
     .default_value(false)
     .implicit_value(true)
     .help("List all volumes in the file and exit");
 
-  args.add_argument("-o", "-p", "--origin", "--position")
+  args.add_argument("-p",  "--position")
     .default_value(std::vector<double>{0.0, 0.0, 0.0})
-    .help("Ray origin/position").scan<'g', double>().nargs(3);
+    .help("Ray origin").scan<'g', double>().nargs(3);
 
   args.add_argument("-d", "--direction")
     .default_value(std::vector<double>{0.0, 0.0, 1.0})
@@ -44,7 +41,6 @@ int main(int argc, char** argv) {
     std::cout << args;
     exit(0);
   }
-
 
   // create a mesh manager
   std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
@@ -62,14 +58,16 @@ int main(int argc, char** argv) {
     exit(0);
   }
 
-  MeshID volume = args.get<int>("volume");
-  Position origin = args.get<std::vector<double>>("--origin");
+  Position position = args.get<std::vector<double>>("--position");
   Direction direction = args.get<std::vector<double>>("--direction");
 
-  auto result = xdg->ray_fire(volume, origin, direction);
+  MeshID volume = xdg->find_volume(position, direction);
 
-  std::cout << "Distance: " << result.first << std::endl;
-  std::cout << "Surface: " << result.second << std::endl;
+  if (volume == ID_NONE) {
+    std::cout << "No volume found for position " << position << std::endl;
+  } else {
+    std::cout << "Point " << position << " is in Volume " << volume << std::endl;
+  }
 
   return 0;
 }

--- a/tools/point_in_volume.cpp
+++ b/tools/point_in_volume.cpp
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "xdg/error.h"
+#include "xdg/mesh_manager_interface.h"
+#include "xdg/moab/mesh_manager.h"
+#include "xdg/vec3da.h"
+#include "xdg/xdg.h"
+
+#include "argparse/argparse.hpp"
+
+using namespace xdg;
+
+int main(int argc, char** argv) {
+
+  argparse::ArgumentParser args("XDG Point in Volume Tool", "1.0", argparse::default_arguments::help);
+
+  args.add_argument("filename")
+    .help("Path to the input file");
+
+  args.add_argument("volume")
+    .help("Volume ID to query").scan<'i', int>();
+
+  args.add_argument("-l", "--list")
+    .default_value(false)
+    .implicit_value(true)
+    .help("List all volumes in the file and exit");
+
+  args.add_argument("-p",  "--position")
+    .default_value(std::vector<double>{0.0, 0.0, 0.0})
+    .help("Ray origin").scan<'g', double>().nargs(3);
+
+  args.add_argument("-d", "--direction")
+    .default_value(std::vector<double>{0.0, 0.0, 1.0})
+    .help("Ray direction").scan<'g', double>().nargs(3);
+
+  try {
+    args.parse_args(argc, argv);
+  }
+  catch (const std::runtime_error& err) {
+    std::cout << err.what() << std::endl;
+    std::cout << args;
+    exit(0);
+  }
+
+  // create a mesh manager
+  std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
+  const auto& mm = xdg->mesh_manager();
+  mm->load_file(args.get<std::string>("filename"));
+  mm->init();
+  mm->parse_metadata();
+  xdg->prepare_raytracer();
+
+  if (args.get<bool>("--list")) {
+    std::cout << "Volumes: " << std::endl;
+    for (auto volume : mm->volumes()) {
+      std::cout << volume << std::endl;
+    }
+    exit(0);
+  }
+
+  MeshID volume = args.get<int>("volume");
+  Position position = args.get<std::vector<double>>("--position");
+  Direction direction = args.get<std::vector<double>>("--direction");
+
+  if (xdg->point_in_volume(volume, position, &direction)) {
+    std::cout << "Point " << position << " is in Volume " << volume << " (True)" << std::endl;
+  } else {
+    std::cout << "Point " << position << " is not in Volume " << volume << " (False)" << std::endl;
+  }
+
+  return 0;
+}

--- a/tools/ray_fire.cpp
+++ b/tools/ray_fire.cpp
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "xdg/error.h"
+#include "xdg/mesh_manager_interface.h"
+#include "xdg/moab/mesh_manager.h"
+#include "xdg/vec3da.h"
+#include "xdg/xdg.h"
+
+#include "argparse/argparse.hpp"
+
+using namespace xdg;
+
+int main(int argc, char** argv) {
+
+  argparse::ArgumentParser args("XDG Ray Fire Tool", "1.0", argparse::default_arguments::help);
+
+  args.add_argument("filename")
+    .help("Path to the input file");
+
+  args.add_argument("volume")
+    .help("Volume ID to query").scan<'i', int>();
+
+  args.add_argument("-l", "--list")
+    .default_value(false)
+    .implicit_value(true)
+    .help("List all volumes in the file and exit");
+
+  args.add_argument("-o", "--origin")
+    .default_value(std::vector<double>{0.0, 0.0, 0.0})
+    .help("Ray origin").scan<'g', double>().nargs(3);
+
+  args.add_argument("-d", "--direction")
+    .default_value(std::vector<double>{0.0, 0.0, 1.0})
+    .help("Ray direction").scan<'g', double>().nargs(3);
+
+  try {
+    args.parse_args(argc, argv);
+  }
+  catch (const std::runtime_error& err) {
+    std::cout << err.what() << std::endl;
+    std::cout << args;
+    exit(0);
+  }
+
+
+  // create a mesh manager
+  std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
+  const auto& mm = xdg->mesh_manager();
+  mm->load_file(args.get<std::string>("filename"));
+  mm->init();
+  mm->parse_metadata();
+  xdg->prepare_raytracer();
+
+  if (args.get<bool>("--list")) {
+    std::cout << "Volumes: " << std::endl;
+    for (auto volume : mm->volumes()) {
+      std::cout << volume << std::endl;
+    }
+    exit(0);
+  }
+
+  MeshID volume = args.get<int>("volume");
+  Position origin = args.get<std::vector<double>>("--origin");
+  Direction direction = args.get<std::vector<double>>("--direction");
+
+  auto result = xdg->ray_fire(volume, origin, direction);
+
+  std::cout << "Distance: " << result.first << std::endl;
+  std::cout << "Surface: " << result.second << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
This updates the `particle-sim` tool to take a set of arguments to more easily hammer on changes in direction and ensure user understanding of the tool.

It also adds three new diagnostic tools:
  - `ray-fire`
  - `find-volume`
  - `point-in_volume`
