### PR TITLE
Updates for OpenMC Compatability

### DIFF
--- a/include/xdg/mesh_manager_interface.h
+++ b/include/xdg/mesh_manager_interface.h
@@ -69,7 +69,7 @@ public:
 
   MeshID next_surface_id() const;
 
-  void create_implicit_complement();
+  MeshID create_implicit_complement();
 
   // Metadata methods
   virtual void parse_metadata() = 0;
@@ -85,6 +85,7 @@ public:
   std::vector<MeshID>& volumes() { return volumes_; }
   const std::vector<MeshID>& surfaces() const { return surfaces_; }
   std::vector<MeshID>& surfaces() { return surfaces_; }
+  MeshID implicit_complement() const { return implicit_complement_; }
 
   virtual MeshLibrary mesh_library() const = 0;
 
@@ -96,6 +97,8 @@ protected:
   std::vector<MeshID> volumes_;
   std::vector<MeshID> surfaces_;
 
+  // TODO: attempt to remove this attribute
+  MeshID implicit_complement_ {ID_NONE};
 
 };
 

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -21,7 +21,8 @@ static const std::map<std::string, PropertyType> MOAB_PROPERTY_MAP
 {
   {"mat", PropertyType::MATERIAL},
   {"material", PropertyType::MATERIAL},
-  {"boundary", PropertyType::BOUNDARY_CONDITION}
+  {"boundary", PropertyType::BOUNDARY_CONDITION},
+  {"temp", PropertyType::TEMPERATURE}
 };
 
 
@@ -80,6 +81,8 @@ public:
 
   // Metadata
   void parse_metadata() override;
+
+  void graveyard_check();
 
   // Other
   MeshLibrary mesh_library() const override {return MeshLibrary::MOAB; }

--- a/include/xdg/util/str_utils.h
+++ b/include/xdg/util/str_utils.h
@@ -12,6 +12,13 @@ std::vector<std::string> tokenize(const std::string& str,
 
 std::string& strtrim(std::string& s, std::string symbols=" \t\n\r\f\v");
 
+std::string& to_lower(std::string& str);
+
+std::string& rm_substring(std::string& str, const std::string& substr);
+
+bool ends_with(const std::string& value, const std::string& ending);
+
+bool starts_with(const std::string& value, const std::string& beginning);
 
 } // namespace xdg
 

--- a/src/mesh_manager_interface.cpp
+++ b/src/mesh_manager_interface.cpp
@@ -6,7 +6,7 @@
 
 namespace xdg {
 
-void
+MeshID
 MeshManager::create_implicit_complement()
 {
   // create a new volume
@@ -28,6 +28,10 @@ MeshManager::create_implicit_complement()
 
   // TODO: allow for alternate material assignment in IPC
   volume_metadata_[{ipc_volume, PropertyType::MATERIAL}] = VOID_MATERIAL;
+
+  implicit_complement_ = ipc_volume;
+
+  return ipc_volume;
 }
 
 MeshID MeshManager::next_volume_id() const

--- a/src/mesh_manager_interface.cpp
+++ b/src/mesh_manager_interface.cpp
@@ -15,7 +15,7 @@ MeshManager::create_implicit_complement()
   for (auto surface : this->surfaces()) {
     auto parent_vols = this->get_parent_volumes(surface);
 
-    if (parent_vols.first == ID_NONE)
+  if (parent_vols.first == ID_NONE)
       this->add_surface_to_volume(ipc_volume, surface, Sense::FORWARD);
 
     if (parent_vols.second == ID_NONE)

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -66,6 +66,8 @@ void MOABMeshManager::init() {
     surface_id_map_[moab_surface_ids[i]] = moab_surface_handles[i];
     surfaces_.push_back(moab_surface_ids[i]);
   }
+
+  MeshID ipc = create_implicit_complement();
 }
 
 // Methods
@@ -112,7 +114,7 @@ void MOABMeshManager::add_surface_to_volume(MeshID volume, MeshID surface, Sense
 {
   moab::EntityHandle vol_handle = volume_id_map_.at(volume);
   moab::EntityHandle surf_handle = surface_id_map_.at(surface);
-  this->moab_interface()->add_parent_child(volume, surface);
+  this->moab_interface()->add_parent_child(vol_handle, surf_handle);
 
   // insert new volume into sense data
   auto sense_data = this->surface_senses(surface);
@@ -320,6 +322,10 @@ MOABMeshManager::parse_metadata()
     this->moab_interface()->tag_get_data(name_tag_, &group, 1, group_name.data());
     std::vector<std::string> tokens = tokenize(strtrim(group_name), metadata_delimiters);
 
+    // this group is often present and is meaningless
+    if (tokens.size() == 1 && tokens[0] == "picked")
+      continue;
+
     // ensure we have an even number of tokens
     // TODO: are there any cases in which this shouldn't be true???
     if (tokens.size() % 2 != 0) {
@@ -339,6 +345,21 @@ MOABMeshManager::parse_metadata()
       if (MOAB_PROPERTY_MAP.count(key) == 0)
         fatal_error("Could not find property for key '{}'", key);
       group_properties.push_back({MOAB_PROPERTY_MAP.at(key), value});
+    }
+
+    // separate out implicit complement properties
+    for (auto it = group_properties.begin(); it != group_properties.end();) {
+      auto prop = *it;
+      if (prop.type == PropertyType::MATERIAL && ends_with(prop.value, "_comp")) {
+        rm_substring(prop.value, "_comp");
+        if (implicit_complement() != ID_NONE)
+          volume_metadata_[{implicit_complement(), PropertyType::MATERIAL}] = prop;
+        else
+           write_message(fmt::format("Implicit complement material property '{}' found but no implicit complement volume set", prop.value));
+        it = group_properties.erase(it);
+      } else {
+        ++it;
+      }
     }
 
     // now we have all of the properties. Get the geometric entities they apply to
@@ -361,11 +382,26 @@ MOABMeshManager::parse_metadata()
         for (const auto& p : group_properties) {
           surface_metadata_[{global_id, p.type}] = p;
         }
-
       } else {
         fatal_error("Properties for entities with dimension {} are unsupported", dim);
       }
     }
   }
 
+  graveyard_check();
+}
+
+void
+MOABMeshManager::graveyard_check()
+{
+  for (auto volume : this->volumes()) {
+    auto prop = MeshManager::get_volume_property(volume, PropertyType::MATERIAL);
+    // set the boundary condition to vacuum for all surfaces on volumes using a graveyard material
+    if (to_lower(prop.value) == "graveyard") {
+      auto volume_surfaces = this->get_volume_surfaces(volume);
+      for (auto surface : volume_surfaces) {
+        surface_metadata_[{surface, PropertyType::BOUNDARY_CONDITION}] = {PropertyType::BOUNDARY_CONDITION, "vacuum"};
+      }
+    }
+  }
 }

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -322,8 +322,14 @@ MOABMeshManager::parse_metadata()
 
     // ensure we have an even number of tokens
     // TODO: are there any cases in which this shouldn't be true???
-    if (tokens.size() % 2 != 0)
-      fatal_error("Group name tokens are of incorrect size: {}", tokens.size());
+    if (tokens.size() % 2 != 0) {
+      std:: string msg = fmt::format("Group name tokens ({}) are of incorrect size: {}\n", tokens.size());
+      for (const auto& t : tokens) {
+        msg += fmt::format("{}", t);
+      }
+      msg += "\n";
+      fatal_error(msg);
+    }
 
     std::vector<Property> group_properties;
     // iterate over tokens by 2 and setup property objects

--- a/src/util/str_utils.cpp
+++ b/src/util/str_utils.cpp
@@ -38,4 +38,34 @@ std::string& strtrim(std::string& s, std::string symbols)
   return s;
 }
 
+// from OpenMC, modified
+std::string& to_lower(std::string& str)
+{
+  for (int i = 0; i < str.size(); i++)
+    str[i] = std::tolower(str[i]);
+  return str;
+}
+
+std::string& rm_substring(std::string& str, const std::string& substr)
+{
+  size_t pos = str.find(substr);
+  if (pos != std::string::npos)
+    str.erase(pos, substr.size());
+  return str;
+}
+
+bool ends_with(const std::string& value, const std::string& ending)
+{
+  if (ending.size() > value.size())
+    return false;
+  return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+}
+
+bool starts_with(const std::string& value, const std::string& beginning)
+{
+  if (beginning.size() > value.size())
+    return false;
+  return std::equal(beginning.begin(), beginning.end(), value.begin());
+}
+
 } // namespace xdg

--- a/tests/test_moab.cpp
+++ b/tests/test_moab.cpp
@@ -20,12 +20,12 @@ TEST_CASE("Test MOAB Initialization")
   mesh_manager->load_file("pwr_pincell.h5m");
   mesh_manager->init();
 
-  REQUIRE(mesh_manager->num_volumes() == 3);
+  REQUIRE(mesh_manager->num_volumes() == 4);
   REQUIRE(mesh_manager->num_surfaces() == 12);
 
   // create the implicit complement volume
   mesh_manager->create_implicit_complement();
-  REQUIRE(mesh_manager->num_volumes() == 4);
+  REQUIRE(mesh_manager->num_volumes() == 5);
 
   // parse metadata
   mesh_manager->parse_metadata();
@@ -35,7 +35,8 @@ TEST_CASE("Test MOAB Initialization")
       {1, "UO2 (2.4%)"},
       {2, "Zircaloy"},
       {3, "Hot borated water"},
-      {4, "void"}
+      {4, "void"},
+      {5, "void"}
     };
 
   for (auto volume : mesh_manager->volumes()) {
@@ -58,7 +59,7 @@ TEST_CASE("Test BVH Build")
   mesh_manager->load_file("cube.h5m");
   mesh_manager->init();
 
-  REQUIRE(mesh_manager->num_volumes() == 1);
+  REQUIRE(mesh_manager->num_volumes() == 2);
   REQUIRE(mesh_manager->num_surfaces() == 6);
 
   std::unique_ptr<RayTracer> ray_tracing_interface = std::make_unique<RayTracer>();
@@ -67,7 +68,7 @@ TEST_CASE("Test BVH Build")
     ray_tracing_interface->register_volume(mesh_manager, volume);
   }
 
-  REQUIRE(ray_tracing_interface->num_registered_scenes() == 1);
+  REQUIRE(ray_tracing_interface->num_registered_scenes() == 2);
 }
 
 TEST_CASE("Test Ray Fire MOAB")

--- a/tests/test_overlap_check.cpp
+++ b/tests/test_overlap_check.cpp
@@ -23,7 +23,7 @@ TEST_CASE("Overlapping Volumes Test")
   check_instance_for_overlaps(xdg, overlap_map);
 
   // Expected 1 overlap
-  REQUIRE(overlap_map.size() == 1);
+  REQUIRE(overlap_map.size() == 2);
   std::set<int> expected_overlaps = {1, 2};
 
   // Expected overlaps between volumes [1,2]
@@ -57,7 +57,7 @@ TEST_CASE("Non-Overlapping Imprinted Volumes Test")
   check_instance_for_overlaps(xdg, overlap_map);
 
   // Expected no overlaps
-  REQUIRE(overlap_map.size() == 0); 
+  REQUIRE(overlap_map.size() == 0);
 }
 
 TEST_CASE("Enclosed Volume Test")
@@ -72,11 +72,11 @@ TEST_CASE("Enclosed Volume Test")
   check_instance_for_overlaps(xdg, overlap_map);
 
   // Expected 1 overlap
-  REQUIRE(overlap_map.size() == 1); 
+  REQUIRE(overlap_map.size() == 2);
   std::set<int> expected_overlaps = {1, 2};
 
   // Expected overlaps between volumes [1,2]
-  REQUIRE(expected_overlaps == overlap_map.begin()->first); 
+  REQUIRE(expected_overlaps == overlap_map.begin()->first);
 }
 
 TEST_CASE("Small Overlap Test")
@@ -91,11 +91,11 @@ TEST_CASE("Small Overlap Test")
   check_instance_for_overlaps(xdg, overlap_map);
 
   // Expected 1 overlap
-  REQUIRE(overlap_map.size() == 1); 
+  REQUIRE(overlap_map.size() == 1);
   std::set<int> expected_overlaps = {1, 2};
 
   // Expected overlaps between volumes [1,2]
-  REQUIRE(expected_overlaps == overlap_map.begin()->first); 
+  REQUIRE(expected_overlaps == overlap_map.begin()->first);
 }
 
 


### PR DESCRIPTION
I'd thought that the `xdg` branch in my fork of OpenMC was up to date, but it needed some adjustments. Namely it was missing the ability to ignore the "picked" group that often appears in DAGMC files and is meaningless, the ability to assign implicit complement materials (a frustrating catch 22 to deal with there), and assignment of boundary conditions for graveyard volumes.

These are all idiosyncrasies of the DAGMC file spec and points of origin, so I'm trying to keep additional code and logic manged in the `MOABMeshManager` as much as possible.

 