### PR TITLE
Fix random dir function. Use static direction in overlap checker for now

### DIFF
--- a/include/xdg/vec3da.h
+++ b/include/xdg/vec3da.h
@@ -167,7 +167,7 @@ using Direction = Vec3da;
 
 inline Direction rand_dir() {
   double theta = drand48() * 2.0 * M_PI;
-  double u = (1.0 - drand48()) - 1.0;
+  double u = 2.0*drand48() - 1.0;
   double phi = acos(u);
   return Direction(sin(phi) * cos(theta), sin(phi) * sin(theta), cos(phi)).normalize();
 

--- a/src/overlap_check/overlap.cpp
+++ b/src/overlap_check/overlap.cpp
@@ -16,7 +16,7 @@ void check_location_for_overlap(std::shared_ptr<XDG> xdg,
   for (const auto& vol : all_vols) {
     bool pointInVol = false;
     pointInVol = xdg->point_in_volume(vol, loc, &dir, nullptr);
-    
+
   if (pointInVol) {
     vols_found.insert(vol);
     }
@@ -56,21 +56,22 @@ void check_instance_for_overlaps(std::shared_ptr<XDG> xdg,
   for (const auto& surf:mm->surfaces())
   {
     auto elements_on_surf = mm->get_surface_elements(surf);
-    
+
     for (const auto& tri:elements_on_surf)
     {
       auto triVerts = mm->triangle_vertices(tri);
       // Push vertices in triangle to end of array
-      all_verts.push_back(triVerts[0]); 
-      all_verts.push_back(triVerts[1]); 
-      all_verts.push_back(triVerts[2]); 
+      all_verts.push_back(triVerts[0]);
+      all_verts.push_back(triVerts[1]);
+      all_verts.push_back(triVerts[2]);
     }
   }
 
   // number of locations we'll be checking
   int num_locations = all_verts.size(); // + pnts_per_edge * all_edges.size();
   int num_checked = 1;
-  Direction dir = xdg::rand_dir();
+  Direction dir {0.1, 0.1, 0.1};
+  dir = dir.normalize();
   ProgressBar prog_bar;
 
 // first check all triangle vertex locations


### PR DESCRIPTION
There was an error in the `rand_dir` function for sampling the polar angle. This PR corrects that.

This caused the overlap checker tests to fail. It's unclear as to why b/c the point containment checks should be independent of the ray direction. I'm going to table that for now and create an issue to follow up on later.