### PR TITLE
Fix primitive culling

### DIFF
--- a/src/triangle_intersect.cpp
+++ b/src/triangle_intersect.cpp
@@ -23,14 +23,15 @@ bool orientation_cull(const Direction& ray_dir, const Direction& normal, HitOrie
   return false;
 }
 
-bool primitive_mask_cull(RTCDRayHit* rayhit) {
+bool primitive_mask_cull(RTCDRayHit* rayhit, int primID) {
   if (!rayhit->ray.exclude_primitives) return false;
 
   RTCDRay& ray = rayhit->ray;
   RTCDHit& hit = rayhit->hit;
 
+
   // if the primitive mask is set, cull if the primitive is not in the mask
-  return std::find(ray.exclude_primitives->begin(), ray.exclude_primitives->end(), hit.primID) != ray.exclude_primitives->end();
+  return std::find(ray.exclude_primitives->begin(), ray.exclude_primitives->end(), primID) != ray.exclude_primitives->end();
 }
 
 void TriangleBoundsFunc(RTCBoundsFunctionArguments* args)
@@ -79,7 +80,7 @@ void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
 
   if (rayhit->ray.rf_type == RayFireType::VOLUME) {
    if (orientation_cull(rayhit->ray.ddir, normal, rayhit->ray.orientation)) return;
-   if (primitive_mask_cull(rayhit)) return;
+   if (primitive_mask_cull(rayhit, primitive_ref.primitive_id)) return;
   }
 
   // if we've gotten through all of the filters, set the ray information

--- a/tests/test_ray_fire.cpp
+++ b/tests/test_ray_fire.cpp
@@ -74,4 +74,15 @@ TEST_CASE("Test Ray Fire Mesh Mock")
   intersection = rti->ray_fire(volume_tree, origin, direction, 5.1);
   REQUIRE(intersection.second != ID_NONE);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(5.0, 1e-6));
+
+  // Test excluding primitives, fire a ray from the origin and log the hit face
+  // By providing the hit face as an excluded primitive in a subsequent ray fire,
+  // there should be no intersection returned
+  std::vector<MeshID> exclude_primitives;
+  intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, &exclude_primitives);
+  REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(5.0, 1e-6));
+  REQUIRE(exclude_primitives.size() == 1);
+
+  intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, &exclude_primitives);
+  REQUIRE(intersection.second == ID_NONE);
 }


### PR DESCRIPTION
The primitive culling technique was using hit information about the primitive that was not yet set. The primitive ID is now directly passed to the culling function with these changes. 

A test has been added to ensure that primitive culling works correctly in `test_ray_fire`