### PR TITLE
Cache build dependencies to speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,11 @@ jobs:
       - name: MOAB Cache
         id: moab-cache
         uses: actions/cache@v3
+        env:
+          cache-name: moab-cache
         with:
-          path: $HOME/MOAB
-          key: moab-${{ runner.os }}-${{ hashFiles('~/moab/moab-sha') }}
+          path: ~/MOAB
+          key: moab-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('~/moab/moab-sha') }}
 
       - if: ${{ steps.moab-cache.outputs.cache-hit != 'true' }}
         name: Build MOAB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           cache-name: moab-cache
         with:
           path: ~/MOAB
-          key: moab-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('~/moab/moab-sha*') }}
+          key: moab-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('~/**/moab-sha') }}
 
       - if: ${{ steps.moab-cache.outputs.cache-hit != 'true' }}
         name: Build MOAB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
 
       - if: ${{ steps.moab-cache.outputs.cache-hit != 'true' }}
         name: Build MOAB
+        run: |
           cd ~/moab
           mkdir build
           cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
           git clone https://bitbucket.org/fathomteam/moab.git
           cd moab
           git checkout 5.3.1
-          git rev-parse HEAD > moab-sha
-          cat moab-sha
 
       - name: Environment Variables
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
           cd moab
           git checkout 5.3.1
           git rev-parse HEAD > moab-sha
+          cat moab-sha
+
+      - name: Environment Variables
+        run: |
+          echo "MOAB_SHA"=$(cd ~/moab && git rev-parse HEAD) >> $GITHUB_ENV
 
       - name: MOAB Cache
         id: moab-cache
@@ -44,7 +49,7 @@ jobs:
           cache-name: moab-cache
         with:
           path: ~/MOAB
-          key: moab-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('~/**/moab-sha') }}
+          key: moab-${{ runner.os }}-${{ env.cache-name }}-${{ env.MOAB_SHA }}
 
       - if: ${{ steps.moab-cache.outputs.cache-hit != 'true' }}
         name: Build MOAB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           cache-name: moab-cache
         with:
           path: ~/MOAB
-          key: moab-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('~/moab/moab-sha') }}
+          key: moab-${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('~/moab/moab-sha*') }}
 
       - if: ${{ steps.moab-cache.outputs.cache-hit != 'true' }}
         name: Build MOAB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,7 @@ jobs:
         id: moab-cache
         uses: actions/cache@v3
         with:
-          paths:
-            - $HOME/MOAB
+          path: $HOME/MOAB
           key: moab-${{ runner.os }}-${{ hashFiles('~/moab/moab-sha') }}
 
       - if: ${{ steps.moab-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,29 @@ jobs:
                               libeigen3-dev \
                               cmake
 
-      - name: Build MOAB
+      - name: MOAB Clone
         shell: bash
         run: |
           cd ~
           git clone https://bitbucket.org/fathomteam/moab.git
           cd moab
           git checkout 5.3.1
+          git rev-parse HEAD > moab-sha
+
+      - name: MOAB Cache
+        id: moab-cache
+        uses: actions/cache@v3
+        with:
+          paths:
+            - $HOME/MOAB
+          key: moab-${{ runner.os }}-${{ hashFiles('~/moab/moab-sha') }}
+
+      - if: ${{ steps.moab-cache.outputs.cache-hit != 'true' }}
+        name: Build MOAB
+          cd ~/moab
           mkdir build
           cd build
-          cmake -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF -DCMAKE_INSTALL_PREFIX=$HOME/opt -DCMAKE_BUILD_TYPE=Release ..
+          cmake -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF -DCMAKE_INSTALL_PREFIX=$HOME/MOAB -DCMAKE_BUILD_TYPE=Release ..
           make -j4
           make install
 
@@ -46,7 +59,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_PREFIX_PATH=$HOME/opt -DCMAKE_INSTALL_PREFIX=$HOME/opt
+          cmake .. -DCMAKE_PREFIX_PATH=$HOME/MOAB -DCMAKE_INSTALL_PREFIX=$HOME/opt
           make -j4 install
 
       - name: Test

--- a/.github/workflows/openmc-test.yml
+++ b/.github/workflows/openmc-test.yml
@@ -34,30 +34,65 @@ jobs:
           echo "PATH=$HOME/opt/bin:$PATH" >> $GITHUB_ENV
 
 
-      - name: Build MOAB
+      - name: Clone MOAB
         shell: bash
         run: |
           cd ~
           git clone https://bitbucket.org/fathomteam/moab.git
           cd moab
           git checkout 5.3.1
-          mkdir build
-          cd build
-          cmake -DCMAKE_INSTALL_PREFIX=$HOME/opt -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF  -DCMAKE_BUILD_TYPE=Release ..
-          make -j4
-          make install
 
-      - name: Build libMesh
+      - name: Clone libMesh
         shell: bash
         run: |
           cd ~
           git clone https://github.com/libMesh/libmesh.git
           cd libmesh
           git checkout v1.7.0
+
+      - name: Cache Variables
+        run: |
+          echo "MOAB_SHA"=$(cd ~/moab && git rev-parse HEAD) >> $GITHUB_ENV
+          echo "LIBMESH_SHA"=$(cd ~/libmesh && git rev-parse HEAD) >> $GITHUB_ENV
+
+      - name: MOAB Cache
+        id: moab-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: moab-cache
+        with:
+          path: ~/MOAB
+          key: moab-${{ runner.os }}-${{ env.cache-name }}-${{ env.MOAB_SHA }}
+
+      - name: libMesh Cache
+        id: libmesh-cache
+        uses: actions/cache@v3
+        env:
+          cache-name: libmesh-cache
+        with:
+          path: ~/LIBMESH
+          key: libmesh-${{ runner.os }}-${{ env.cache-name }}-${{ env.LIBMESH_SHA }}
+
+      - if: ${{ steps.moab-cache.outputs.cache-hit != 'true' }}
+        name: Build MOAB
+        shell: bash
+        run: |
+          cd ~/moab
+          mkdir build
+          cd build
+          cmake -DCMAKE_INSTALL_PREFIX=$HOME/MOAB -DENABLE_HDF5=ON -DENABLE_BLASLAPACK=OFF  -DCMAKE_BUILD_TYPE=Release ..
+          make -j4
+          make install
+
+      - if: ${{ steps.libmesh-cache.outputs.cache-hit != 'true' }}
+        name: Build libMesh
+        shell: bash
+        run: |
+          cd ~/libmesh
           git submodule update --init --recursive
           mkdir build
           cd build
-          ../configure --prefix=$HOME/opt --enable-exodus --disable-netcdf4 --disable-eigen --disable-lapack --disable-mpi --disable-metaphysicl
+          ../configure --prefix=$HOME/LIBMESH --enable-exodus --disable-netcdf4 --disable-eigen --disable-lapack --disable-mpi --disable-metaphysicl
           make -j4
           make install
 
@@ -66,7 +101,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/opt -DCMAKE_PREFIX_PATH=$HOME/opt -DXDG_ENABLE_MOAB=ON -DXDG_ENABLE_LIBMESH=ON
+          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/opt -DCMAKE_PREFIX_PATH="$HOME/MOAB:$HOME/LIBMESH" -DXDG_ENABLE_MOAB=ON -DXDG_ENABLE_LIBMESH=ON
           make -j4 all install
 
       - name: Build OpenMC

--- a/.github/workflows/openmc-test.yml
+++ b/.github/workflows/openmc-test.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/opt -DCMAKE_PREFIX_PATH="$HOME/MOAB:$HOME/LIBMESH" -DXDG_ENABLE_MOAB=ON -DXDG_ENABLE_LIBMESH=ON
+          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/opt -DCMAKE_PREFIX_PATH="$HOME/MOAB;$HOME/LIBMESH" -DXDG_ENABLE_MOAB=ON -DXDG_ENABLE_LIBMESH=ON
           make -j4 all install
 
       - name: Build OpenMC


### PR DESCRIPTION
This caches the MOAB build to speed up CI. I'll apply it to other dependencies as they come up.