### PR TITLE
Changes to CMake to support a wider range of Embree versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,29 @@ if (XDG_ENABLE_MOAB)
 find_package(MOAB REQUIRED HINTS ${MOAB_DIR})
 endif()
 
-# use Embree for CPU ray tracing
-find_package(embree 3.0.0...4.0.0 REQUIRED)
+# find Embree for CPU ray tracing
+
+# Because Embree doesn't support version ranges there's a limitation
+# that the "requested" major version matches that of the Embree package.
+# For version ranges, this appears to go in as the lower bound of the
+# version range.
+
+# attempt once for Embree versions between 4 and 5
+find_package(embree 4.0.0...<4.1.0 PATHS ${CMAKE_PREFIX_PATH})
+# if Embree wasn't found, try again for versions between 3 and 4
+if (NOT DEFINED EMBREE_VERSION)
+   message(WARNING "Could not find an Embree version > v4.0. \nSearching for older versions of Embree...")
+   find_package(embree 3.0.0...<4.0.0 REQUIRED PATHS ${CMAKE_PREFIX_PATH})
+endif()
+
+if (NOT DEFINED EMBREE_VERSION)
+  message(FATAL_ERROR "Embree package was not found")
+endif()
 if (NOT ${EMBREE_VERSION} VERSION_GREATER 3.6.0)
   message(FATAL_ERROR "XDG requires Embree v3.6.1 or higher.")
 endif()
+
+message(STATUS "Found Embree ${EMBREE_VERSION} at ${EMBREE_ROOT_DIR}")
 
 # Catch2 testing module
 if (XDG_BUILD_TESTS)

--- a/cmake/XDGConfig.cmake.in
+++ b/cmake/XDGConfig.cmake.in
@@ -1,7 +1,7 @@
 get_filename_component(XDG_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 
 find_package(fmt REQUIRED HINTS ${XDG_CMAKE_DIR}/../fmt)
-find_package(embree 3.6.1 REQUIRED HINTS @EMBREE_DIR@)
+find_package(embree @EMBREE_VERSION@ REQUIRED HINTS @EMBREE_ROOT_DIR@)
 
 if(@XDG_ENABLE_MOAB@)
   find_package(MOAB REQUIRED HINTS @MOAB_DIR@)


### PR DESCRIPTION
This implements a set of changes to support a wider set of Embree versions. Recently, CI broke here because the OS on GitHub actions updated and the new Embree debian package jumped to a version newer than 4.0. 

As a result of this I found out that the Embree CMake configuration (generated through CPack)  doesn't support version ranges at all. The cleanest way I could think of to remedy this is to call `find_package` twice, once with a minimum version 4.0.0 and then 3.0.0 if the first call isn't successful.