### PR TITLE
Resolve #4 to remove the extra triangle references being stored

### DIFF
--- a/include/xdg/embree/ray_tracer.h
+++ b/include/xdg/embree/ray_tracer.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "xdg/constants.h"
 #include "xdg/embree_interface.h"
@@ -71,6 +72,9 @@ public:
 
   // storage
   std::unordered_map<RTCScene, std::vector<PrimitiveRef>> primitive_ref_storage_;
+
+private:
+  std::unordered_set<MeshID> global_surface_cache_;
 };
 
 } // namespace xdg

--- a/include/xdg/embree/ray_tracer.h
+++ b/include/xdg/embree/ray_tracer.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <vector>
 #include <unordered_map>
-#include <unordered_set>
 
 #include "xdg/constants.h"
 #include "xdg/embree_interface.h"
@@ -74,7 +73,6 @@ public:
   std::unordered_map<RTCScene, std::vector<PrimitiveRef>> primitive_ref_storage_;
 
 private:
-  std::unordered_set<MeshID> global_surface_cache_;
 };
 
 } // namespace xdg

--- a/include/xdg/embree/ray_tracer.h
+++ b/include/xdg/embree/ray_tracer.h
@@ -71,8 +71,6 @@ public:
 
   // storage
   std::unordered_map<RTCScene, std::vector<PrimitiveRef>> primitive_ref_storage_;
-
-private:
 };
 
 } // namespace xdg

--- a/include/xdg/embree/ray_tracer.h
+++ b/include/xdg/embree/ray_tracer.h
@@ -71,6 +71,12 @@ public:
 
   // storage
   std::unordered_map<RTCScene, std::vector<PrimitiveRef>> primitive_ref_storage_;
+
+private:
+  std::pair<RTCGeometry, std::shared_ptr<GeometryUserData>> register_surface(const std::shared_ptr<MeshManager>& mesh_manager,
+                                                                             MeshID surface, 
+                                                                             RTCScene& volume_scene, 
+                                                                             int& storage_offset);
 };
 
 } // namespace xdg

--- a/include/xdg/geometry_data.h
+++ b/include/xdg/geometry_data.h
@@ -14,8 +14,8 @@ struct GeometryUserData {
   MeshManager* mesh_manager {nullptr}; //! Pointer to the mesh manager for this geometry
   PrimitiveRef* prim_ref_buffer {nullptr}; //! Pointer to the mesh primitives in the geometry
   double box_bump; //! Bump distance for the bounding boxes in this geometry
-  MeshID forward_sense {ID_NONE}; // ID of the forward sense volume
-  MeshID reverse_sense {ID_NONE}; // ID of the reverse sense volume
+  MeshID forward_vol {ID_NONE}; // ID of the forward sense volume
+  MeshID reverse_vol {ID_NONE}; // ID of the reverse sense volume
 };
 
 struct VolumeElementsUserData {

--- a/include/xdg/geometry_data.h
+++ b/include/xdg/geometry_data.h
@@ -14,6 +14,8 @@ struct GeometryUserData {
   MeshManager* mesh_manager {nullptr}; //! Pointer to the mesh manager for this geometry
   PrimitiveRef* prim_ref_buffer {nullptr}; //! Pointer to the mesh primitives in the geometry
   double box_bump; //! Bump distance for the bounding boxes in this geometry
+  MeshID forward_sense {ID_NONE}; // ID of the forward sense volume
+  MeshID reverse_sense {ID_NONE}; // ID of the reverse sense volume
 };
 
 struct VolumeElementsUserData {

--- a/include/xdg/primitive_ref.h
+++ b/include/xdg/primitive_ref.h
@@ -9,7 +9,6 @@ namespace xdg {
 
 struct PrimitiveRef {
   MeshID primitive_id {ID_NONE};
-  Sense sense {Sense::UNSET};
 };
 
 void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args);

--- a/include/xdg/ray.h
+++ b/include/xdg/ray.h
@@ -88,7 +88,7 @@ struct RTCSurfaceDualRay : RTCDualRay {
   RayFireType rf_type {RayFireType::VOLUME}; //!< Enum indicating the type of query this ray is used for
   HitOrientation orientation {HitOrientation::EXITING}; //!< Enum indicating what hits to accept based on orientation
   const std::vector<MeshID>* exclude_primitives {nullptr}; //! < Set of primitives to exclude from the query
-  TreeID volume {ID_NONE}; // volume the ray is being fired in
+  TreeID volume_tree {ID_NONE}; // volume the ray is being fired in
 };
 
 struct RTCElementDualRay : RTCDualRay {

--- a/include/xdg/ray.h
+++ b/include/xdg/ray.h
@@ -88,6 +88,7 @@ struct RTCSurfaceDualRay : RTCDualRay {
   RayFireType rf_type {RayFireType::VOLUME}; //!< Enum indicating the type of query this ray is used for
   HitOrientation orientation {HitOrientation::EXITING}; //!< Enum indicating what hits to accept based on orientation
   const std::vector<MeshID>* exclude_primitives {nullptr}; //! < Set of primitives to exclude from the query
+  TreeID volume {ID_NONE}; // volume the ray is being fired in
 };
 
 struct RTCElementDualRay : RTCDualRay {

--- a/src/embree/ray_tracer.cpp
+++ b/src/embree/ray_tracer.cpp
@@ -62,9 +62,7 @@ TreeID EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_
     // Check if this surface already has a cached surface geometry
     if (!surface_to_geometry_map_.count(surface)) 
     { // First visit: Create new RTCGeometry and GeometryUserData
-      auto registeredSurface = register_surface(mesh_manager, surface, volume_scene, storage_offset);
-      surface_geometry = registeredSurface.first;
-      surface_data = registeredSurface.second;
+      std::tie(surface_geometry, surface_data) = register_surface(mesh_manager, surface, volume_scene, storage_offset);
     } 
     else { // Second Visit: Recover existing RTCGeometry and GeometryUserData
       surface_geometry = surface_to_geometry_map_[surface];
@@ -76,10 +74,10 @@ TreeID EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_
     }
 
     // Set the correct parent TreeID
-    auto parents = mesh_manager->get_parent_volumes(surface);
-    if (volume_id == parents.first) {
+    auto [forward_parent, reverse_parent] = mesh_manager->surface_senses(surface);
+    if (volume_id == forward_parent) {
       surface_data->forward_vol = tree;
-    } else if (volume_id == parents.second) {
+    } else if (volume_id == reverse_parent) {
       surface_data->reverse_vol = tree;
     } else {
       fatal_error("Volume {} is not a parent of surface {}", volume_id, surface);

--- a/src/embree/ray_tracer.cpp
+++ b/src/embree/ray_tracer.cpp
@@ -32,85 +32,82 @@ RTCScene EmbreeRayTracer::create_embree_scene() {
   rtcSetSceneBuildQuality(rtcscene, RTC_BUILD_QUALITY_HIGH);
   return rtcscene;
 }
-
-TreeID
-EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
-                           MeshID volume_id)
+TreeID EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
+                                        MeshID volume_id)
 {
   TreeID tree = next_tree_id();
   trees_.push_back(tree);
   auto volume_scene = this->create_embree_scene();
 
-  // allocate storage for this volume
-  auto volume_faces = mesh_manager->get_volume_faces(volume_id);
-  this->primitive_ref_storage_[volume_scene].resize(volume_faces.size());
-  auto& triangle_storage = this->primitive_ref_storage_[volume_scene];
-
   auto volume_surfaces = mesh_manager->get_volume_surfaces(volume_id);
-  int storage_offset {0};
+
+  // Get the number of prims that need to be added
+  size_t total_face_count = 0;
   for (auto& surface_id : volume_surfaces) {
-    // get the sense of this surface with respect to the volume
-    Sense triangle_sense {Sense::UNSET};
-    auto surf_to_vol_senses = mesh_manager->get_parent_volumes(surface_id);
-    if (volume_id == surf_to_vol_senses.first) triangle_sense = Sense::FORWARD;
-    else if (volume_id == surf_to_vol_senses.second) triangle_sense = Sense::REVERSE;
-    else fatal_error("Volume {} is not a parent of surface {}", volume_id, surface_id);
-
-    auto surface_faces = mesh_manager->get_surface_faces(surface_id);
-    for (int i = 0; i < surface_faces.size(); ++i) {
-      auto& primitive_ref = triangle_storage[i + storage_offset];
-      primitive_ref.primitive_id = surface_faces[i];
-      primitive_ref.sense = triangle_sense;
+    if (global_surface_cache_.find(surface_id) == global_surface_cache_.end()) {
+      total_face_count += mesh_manager->get_surface_faces(surface_id).size();
     }
-    storage_offset += surface_faces.size();
- }
+  }
 
+  this->primitive_ref_storage_[volume_scene].resize(total_face_count);
+  auto& triangle_storage = this->primitive_ref_storage_[volume_scene];
   PrimitiveRef* tri_ref_ptr = triangle_storage.data();
 
   auto bump = bounding_box_bump(mesh_manager, volume_id);
-/*
-  TODO: none of the above is ray tracer specific. This can be a part of the common register_volume
-  implementation. Then another virtual function can be called register_volume_RT_specific.
-  in this scenario register_volume isn't a virtual function but instead calls a virtual function.
-  That virtual function will be overrided to do the RT specific things in registering the volume.
-  Primitive_ref_storage is the only non-local variable used in this context that is a member of the derived class.
-  However when implementing GPRT the above may need to be written differently with GPU buffers in mind.
-  So we will leave it as is for now.
-*/
 
-  // create a new geometry for each surface
-  int buffer_start = 0;
-  for (auto surface : volume_surfaces) {
-    auto surface_triangles = mesh_manager->get_surface_faces(surface);
+  int storage_offset = 0;
+  for (auto& surface : volume_surfaces) {
+    // Skip if surface already cached by another volume
+    if (global_surface_cache_.find(surface) != global_surface_cache_.end()) {
+      continue;
+    }
+
+    // Mark surface as handled globally
+    global_surface_cache_.insert(surface);
+
+    auto surface_faces = mesh_manager->get_surface_faces(surface);
+    size_t num_faces = surface_faces.size();
+
+    // Fill primitive refs
+    for (size_t i = 0; i < num_faces; ++i) {
+      triangle_storage[storage_offset + i].primitive_id = surface_faces[i];
+    }
+
     RTCGeometry surface_geometry = rtcNewGeometry(device_, RTC_GEOMETRY_TYPE_USER);
-    rtcSetGeometryUserPrimitiveCount(surface_geometry, surface_triangles.size());
-    unsigned int embree_surface = rtcAttachGeometry(volume_scene, surface_geometry);
+    rtcSetGeometryUserPrimitiveCount(surface_geometry, num_faces);
+    rtcAttachGeometry(volume_scene, surface_geometry);
     this->surface_to_geometry_map_[surface] = surface_geometry;
 
-    std::shared_ptr<GeometryUserData> surface_data = std::make_shared<GeometryUserData>();
+    auto parents = mesh_manager->get_parent_volumes(surface);
+    if (volume_id != parents.first && volume_id != parents.second) {
+      fatal_error("Volume {} is not a parent of surface {}", volume_id, surface);
+    }
+
+    auto surface_data = std::make_shared<GeometryUserData>();
     surface_data->box_bump = bump;
     surface_data->surface_id = surface;
     surface_data->mesh_manager = mesh_manager.get();
-    surface_data->prim_ref_buffer = tri_ref_ptr + buffer_start;
+    surface_data->prim_ref_buffer = tri_ref_ptr + storage_offset;
+    surface_data->forward_vol = parents.first;
+    surface_data->reverse_vol = parents.second;
+  std::cout << "Registering surface = " << surface_data->surface_id << std::endl;
+  std::cout
+          << "user_data->forward_vol = " << surface_data->forward_vol
+          << " | user_data->reverse_vol = " << surface_data->reverse_vol
+          << std::endl;
+
     user_data_map_[surface_geometry] = surface_data;
+    rtcSetGeometryUserData(surface_geometry, surface_data.get());
 
-    // TODO: This could be a problem if user_data_map_ is reallocated?
-    rtcSetGeometryUserData(surface_geometry, user_data_map_[surface_geometry].get());
-
-    for (int i = 0; i < surface_triangles.size(); ++i) {
-      auto& triangle_ref = surface_data->prim_ref_buffer[i];
-    }
-    buffer_start += surface_triangles.size();
-
-    // set the bounds function
     rtcSetGeometryBoundsFunction(surface_geometry, (RTCBoundsFunction)&TriangleBoundsFunc, nullptr);
     rtcSetGeometryIntersectFunction(surface_geometry, (RTCIntersectFunctionN)&TriangleIntersectionFunc);
     rtcSetGeometryOccludedFunction(surface_geometry, (RTCOccludedFunctionN)&TriangleOcclusionFunc);
-
     rtcCommitGeometry(surface_geometry);
-  }
-  rtcCommitScene(volume_scene);
 
+    storage_offset += num_faces;
+  }
+
+  rtcCommitScene(volume_scene);
   tree_to_scene_map_[tree] = volume_scene;
   return tree;
 }
@@ -129,6 +126,7 @@ bool EmbreeRayTracer::point_in_volume(TreeID tree,
   rayhit.ray.orientation = HitOrientation::ANY;
   rayhit.ray.set_tfar(INFTY);
   rayhit.ray.set_tnear(0.0);
+  rayhit.ray.volume = tree;
 
   if (exclude_primitives != nullptr) rayhit.ray.exclude_primitives = exclude_primitives;
 
@@ -162,6 +160,8 @@ EmbreeRayTracer::ray_fire(TreeID tree,
   rayhit.ray.rf_type = RayFireType::VOLUME;
   rayhit.ray.orientation = orientation;
   rayhit.ray.mask = -1; // no mask
+  rayhit.ray.volume = tree;
+
   if (exclude_primitves != nullptr) rayhit.ray.exclude_primitives = exclude_primitves;
 
   // fire the ray
@@ -176,6 +176,7 @@ EmbreeRayTracer::ray_fire(TreeID tree,
   if (rayhit.hit.geomID == RTC_INVALID_GEOMETRY_ID)
     return {INFTY, ID_NONE};
   else
+
     if (exclude_primitves) exclude_primitves->push_back(rayhit.hit.primitive_ref->primitive_id);
     return {rayhit.ray.dtfar, rayhit.hit.surface};
 }

--- a/src/embree/ray_tracer.cpp
+++ b/src/embree/ray_tracer.cpp
@@ -59,10 +59,11 @@ TreeID EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_
     RTCGeometry surface_geometry;
     std::shared_ptr<GeometryUserData> surface_data;
 
-    // Check if this surface already has a cached surface geometry
+    // Check if this surface already has a cached RTCGeometry and GeometryUserData
     if (!surface_to_geometry_map_.count(surface)) 
     { // First visit: Create new RTCGeometry and GeometryUserData
       std::tie(surface_geometry, surface_data) = register_surface(mesh_manager, surface, volume_scene, storage_offset);
+      surface_data->box_bump = bump; // set the box dilation value
     } 
     else { // Second Visit: Recover existing RTCGeometry and GeometryUserData
       surface_geometry = surface_to_geometry_map_[surface];

--- a/src/embree/ray_tracer.cpp
+++ b/src/embree/ray_tracer.cpp
@@ -94,6 +94,9 @@ TreeID EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_
     else { // Already exists: get geometry and user data
       surface_geometry = surface_to_geometry_map_[surface];
       surface_data = user_data_map_.at(surface_geometry);
+      // set the box dilation value to the larger of the two box bump values for 
+      // the volumes on either side of this surface
+      surface_data->bump = std::max(surface_data->bump, bump);
       rtcAttachGeometry(volume_scene, surface_geometry);
     }
 

--- a/src/embree/ray_tracer.cpp
+++ b/src/embree/ray_tracer.cpp
@@ -96,7 +96,7 @@ TreeID EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_
       surface_data = user_data_map_.at(surface_geometry);
       // set the box dilation value to the larger of the two box bump values for 
       // the volumes on either side of this surface
-      surface_data->bump = std::max(surface_data->bump, bump);
+      surface_data->box_bump = std::max(surface_data->box_bump, bump);
       rtcAttachGeometry(volume_scene, surface_geometry);
     }
 
@@ -130,7 +130,7 @@ bool EmbreeRayTracer::point_in_volume(TreeID tree,
   rayhit.ray.orientation = HitOrientation::ANY;
   rayhit.ray.set_tfar(INFTY);
   rayhit.ray.set_tnear(0.0);
-  rayhit.ray.volume = tree;
+  rayhit.ray.volume_tree = tree;
 
   if (exclude_primitives != nullptr) rayhit.ray.exclude_primitives = exclude_primitives;
 
@@ -164,7 +164,7 @@ EmbreeRayTracer::ray_fire(TreeID tree,
   rayhit.ray.rf_type = RayFireType::VOLUME;
   rayhit.ray.orientation = orientation;
   rayhit.ray.mask = -1; // no mask
-  rayhit.ray.volume = tree;
+  rayhit.ray.volume_tree = tree;
 
   if (exclude_primitves != nullptr) rayhit.ray.exclude_primitives = exclude_primitves;
 

--- a/src/ray_tracing_interface.cpp
+++ b/src/ray_tracing_interface.cpp
@@ -1,9 +1,7 @@
 #include <algorithm>
 #include "xdg/ray_tracing_interface.h"
 
-// So far, most of the methods in RayTracer require quite specific implementations to their RT backend.
-// register_volume() is an exception to this.
-// I imagine the find_volume algorithm may have some common logic which can sit in here once its implemented.
+// Any methods which are identical for all RT backends should be defined here
 
 namespace xdg {
 

--- a/src/triangle_intersect.cpp
+++ b/src/triangle_intersect.cpp
@@ -87,12 +87,6 @@ void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
                |
     In this scenario we flip the normal
   */ 
-std::cout << "Intersecting surface = " << user_data->surface_id << std::endl;
-  std::cout << "ray.volume = " << ray.volume
-          << " | user_data->forward_vol = " << user_data->forward_vol
-          << " | user_data->reverse_vol = " << user_data->reverse_vol
-          << std::endl;
-
 
   // if this is a normal ray fire, flip the normal as needed
   if (ray.volume == user_data->reverse_vol && rayhit->ray.rf_type != RayFireType::FIND_VOLUME)

--- a/src/triangle_intersect.cpp
+++ b/src/triangle_intersect.cpp
@@ -1,5 +1,4 @@
 #include <algorithm> // for find
-#include <iostream>
 
 #include "xdg/geometry/closest.h"
 #include "xdg/primitive_ref.h"

--- a/src/triangle_intersect.cpp
+++ b/src/triangle_intersect.cpp
@@ -74,19 +74,7 @@ void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
 
   Direction normal = mesh_manager->face_normal(primitive_ref.primitive_id);
 
-  /* which volume are we in?
-
-      Reverse    |    Forwards
-           ----->|
-                 |
-    In this scenario we do not flip the normal
-
-      Reverse   |    Forwards
-                |<-----
-                |
-    In this scenario we flip the normal
-  */ 
-
+  // Check if ray is entering or exiting the volume it was fired against
   // if this is a normal ray fire, flip the normal as needed
   if (ray.volume_tree == user_data->reverse_vol && rayhit->ray.rf_type != RayFireType::FIND_VOLUME)
   {  

--- a/src/triangle_intersect.cpp
+++ b/src/triangle_intersect.cpp
@@ -92,7 +92,6 @@ void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
   if (ray.volume == user_data->reverse_vol && rayhit->ray.rf_type != RayFireType::FIND_VOLUME)
   {  
     normal = -normal;
-    std::cout << "primitive_ref.primitive_id = " << primitive_ref.primitive_id << std::endl;
   }
 
   if (rayhit->ray.rf_type == RayFireType::VOLUME) {

--- a/src/triangle_intersect.cpp
+++ b/src/triangle_intersect.cpp
@@ -76,14 +76,14 @@ void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
 
   /* which volume are we in?
 
-     Reverse    |    Forwards
-          ----->|
-                |
+      Reverse    |    Forwards
+           ----->|
+                 |
     In this scenario we do not flip the normal
 
-     Reverse   |    Forwards
-               |<-----
-               |
+      Reverse   |    Forwards
+                |<-----
+                |
     In this scenario we flip the normal
   */ 
 

--- a/src/triangle_intersect.cpp
+++ b/src/triangle_intersect.cpp
@@ -88,7 +88,7 @@ void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
   */ 
 
   // if this is a normal ray fire, flip the normal as needed
-  if (ray.volume == user_data->reverse_vol && rayhit->ray.rf_type != RayFireType::FIND_VOLUME)
+  if (ray.volume_tree == user_data->reverse_vol && rayhit->ray.rf_type != RayFireType::FIND_VOLUME)
   {  
     normal = -normal;
   }

--- a/src/triangle_intersect.cpp
+++ b/src/triangle_intersect.cpp
@@ -74,7 +74,7 @@ void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
 
   Direction normal = mesh_manager->face_normal(primitive_ref.primitive_id);
   // if this is a normal ray fire, flip the normal as needed
-  if (primitive_ref.sense == Sense::REVERSE && rayhit->ray.rf_type != RayFireType::FIND_VOLUME)
+  if (args->geomID == user_data->reverse_sense && rayhit->ray.rf_type != RayFireType::FIND_VOLUME)
     normal = -normal;
 
   if (rayhit->ray.rf_type == RayFireType::VOLUME) {


### PR DESCRIPTION
Wanted to get a draft PR up to resolve #4. 

- Added a `MeshID` for forwards and reverse sense to the `GeometryUserData` struct
- Replaced previous references to `primtive_ref.sense` to use the new members in the `GeometryUserData`

**Question** - in #4 its mentioned that an idea of the scene a ray is being fired upon would need to be stored in `RTCDRay`. I notice that `RTCDRayHit` already defines a `geomID`: 
```
struct RTCDHit : RTCHit {
  RTCDHit() {
    this->geomID = RTC_INVALID_GEOMETRY_ID;
    this->primID = RTC_INVALID_GEOMETRY_ID;
    this->Ng_x = 0.0;
    this->Ng_y = 0.0;
    this->Ng_z = 0.0;
  }
```
Is this `geomID` not that scene the ray is being fired upon? Should `RTCDRay` also additionally store a `geomID` or `sceneID`?