### PR TITLE
Expose ray orientation in ray_fire signature

### DIFF
--- a/include/xdg/ray_tracing_interface.h
+++ b/include/xdg/ray_tracing_interface.h
@@ -41,8 +41,8 @@ public:
                                      const Position& origin,
                                      const Direction& direction,
                                      const double dist_limit = INFTY,
-                                     std::vector<MeshID>* const exclude_primitives = nullptr,
-                                     HitOrientation orientation = HitOrientation::EXITING);
+                                     HitOrientation orientation = HitOrientation::EXITING,
+                                     std::vector<MeshID>* const exclude_primitives = nullptr);
 
   void closest(TreeID scene,
                const Position& origin,

--- a/include/xdg/ray_tracing_interface.h
+++ b/include/xdg/ray_tracing_interface.h
@@ -41,7 +41,8 @@ public:
                                      const Position& origin,
                                      const Direction& direction,
                                      const double dist_limit = INFTY,
-                                     std::vector<MeshID>* const exclude_primitives = nullptr);
+                                     std::vector<MeshID>* const exclude_primitives = nullptr,
+                                     HitOrientation orientation = HitOrientation::EXITING);
 
   void closest(TreeID scene,
                const Position& origin,

--- a/include/xdg/xdg.h
+++ b/include/xdg/xdg.h
@@ -37,8 +37,8 @@ std::pair<double, MeshID> ray_fire(MeshID volume,
                                    const Position& origin,
                                    const Direction& direction,
                                    const double dist_limit = INFTY,
-                                   std::vector<MeshID>* const exclude_primitives = nullptr,
-                                   HitOrientation orientation = HitOrientation::EXITING) const;
+                                   HitOrientation orientation = HitOrientation::EXITING,
+                                   std::vector<MeshID>* const exclude_primitives = nullptr) const;
 
 void closest(MeshID volume,
               const Position& origin,

--- a/include/xdg/xdg.h
+++ b/include/xdg/xdg.h
@@ -37,7 +37,8 @@ std::pair<double, MeshID> ray_fire(MeshID volume,
                                    const Position& origin,
                                    const Direction& direction,
                                    const double dist_limit = INFTY,
-                                   std::vector<MeshID>* const exclude_primitives = nullptr) const;
+                                   std::vector<MeshID>* const exclude_primitives = nullptr,
+                                   HitOrientation orientation = HitOrientation::EXITING) const;
 
 void closest(MeshID volume,
               const Position& origin,

--- a/src/ray_tracing_interface.cpp
+++ b/src/ray_tracing_interface.cpp
@@ -151,8 +151,9 @@ RayTracer::ray_fire(TreeID scene,
                     const Position& origin,
                     const Direction& direction,
                     const double dist_limit,
-                    std::vector<MeshID>* const exclude_primitves)
-{
+                    std::vector<MeshID>* const exclude_primitves,
+                    HitOrientation orientation)
+{     
   RTCDRayHit rayhit;
   // set ray data
   rayhit.ray.set_org(origin);
@@ -160,7 +161,7 @@ RayTracer::ray_fire(TreeID scene,
   rayhit.ray.set_tfar(dist_limit);
   rayhit.ray.set_tnear(0.0);
   rayhit.ray.rf_type = RayFireType::VOLUME;
-  rayhit.ray.orientation = HitOrientation::EXITING;
+  rayhit.ray.orientation = orientation;
   rayhit.ray.mask = -1; // no mask
   if (exclude_primitves != nullptr) rayhit.ray.exclude_primitives = exclude_primitves;
 

--- a/src/ray_tracing_interface.cpp
+++ b/src/ray_tracing_interface.cpp
@@ -151,8 +151,8 @@ RayTracer::ray_fire(TreeID scene,
                     const Position& origin,
                     const Direction& direction,
                     const double dist_limit,
-                    std::vector<MeshID>* const exclude_primitves,
-                    HitOrientation orientation)
+                    HitOrientation orientation,
+                    std::vector<MeshID>* const exclude_primitves)
 {     
   RTCDRayHit rayhit;
   // set ray data

--- a/src/xdg.cpp
+++ b/src/xdg.cpp
@@ -60,10 +60,11 @@ XDG::ray_fire(MeshID volume,
               const Position& origin,
               const Direction& direction,
               const double dist_limit,
-              std::vector<MeshID>* const exclude_primitives) const
+              std::vector<MeshID>* const exclude_primitives,
+              HitOrientation orientation) const
 {
   TreeID scene = volume_to_scene_map_.at(volume);
-  return ray_tracing_interface()->ray_fire(scene, origin, direction, dist_limit, exclude_primitives);
+  return ray_tracing_interface()->ray_fire(scene, origin, direction, dist_limit, exclude_primitives, orientation);
 }
 
 void XDG::closest(MeshID volume,

--- a/src/xdg.cpp
+++ b/src/xdg.cpp
@@ -60,11 +60,11 @@ XDG::ray_fire(MeshID volume,
               const Position& origin,
               const Direction& direction,
               const double dist_limit,
-              std::vector<MeshID>* const exclude_primitives,
-              HitOrientation orientation) const
+              HitOrientation orientation,
+              std::vector<MeshID>* const exclude_primitives) const
 {
   TreeID scene = volume_to_scene_map_.at(volume);
-  return ray_tracing_interface()->ray_fire(scene, origin, direction, dist_limit, exclude_primitives, orientation);
+  return ray_tracing_interface()->ray_fire(scene, origin, direction, dist_limit, orientation, exclude_primitives);
 }
 
 void XDG::closest(MeshID volume,

--- a/tests/test_ray_fire.cpp
+++ b/tests/test_ray_fire.cpp
@@ -65,12 +65,12 @@ TEST_CASE("Test Ray Fire Mesh Mock")
   // in this case rays are fired with a HitOrientation::ENTERING. Rays should hit the first surface intersected
   origin = {-10.0, 0.0, 0.0};
   direction = {1.0, 0.0, 0.0};
-  intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, nullptr, HitOrientation::ENTERING);
+  intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, HitOrientation::ENTERING);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(8.0, 1e-6));
 
   origin = {10.0, 0.0, 0.0};
   direction = {-1.0, 0.0, 0.0};
-  intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, nullptr, HitOrientation::ENTERING);
+  intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, HitOrientation::ENTERING);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(5.0, 1e-6));
 
   // limit distance of the ray, shouldn't get a hit
@@ -91,10 +91,10 @@ TEST_CASE("Test Ray Fire Mesh Mock")
   // By providing the hit face as an excluded primitive in a subsequent ray fire,
   // there should be no intersection returned
   std::vector<MeshID> exclude_primitives;
-  intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, &exclude_primitives);
+  intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, HitOrientation::EXITING, &exclude_primitives);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(5.0, 1e-6));
   REQUIRE(exclude_primitives.size() == 1);
 
-  intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, &exclude_primitives);
+  intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, HitOrientation::EXITING, &exclude_primitives);
   REQUIRE(intersection.second == ID_NONE);
 }

--- a/tests/test_ray_fire.cpp
+++ b/tests/test_ray_fire.cpp
@@ -61,6 +61,18 @@ TEST_CASE("Test Ray Fire Mesh Mock")
   intersection = rti->ray_fire(volume_tree, origin, direction);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(12.0, 1e-6));
 
+  // fire from the outside of the cube toward each face, ensuring that the intersection distances are correct
+  // in this case rays are fired with a HitOrientation::ENTERING. Rays should hit the first surface intersected
+  origin = {-10.0, 0.0, 0.0};
+  direction = {1.0, 0.0, 0.0};
+  intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, nullptr, HitOrientation::ENTERING);
+  REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(8.0, 1e-6));
+
+  origin = {10.0, 0.0, 0.0};
+  direction = {-1.0, 0.0, 0.0};
+  intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, nullptr, HitOrientation::ENTERING);
+  REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(5.0, 1e-6));
+
   // limit distance of the ray, shouldn't get a hit
   origin = {0.0, 0.0, 0.0};
   direction = {1.0, 0.0, 0.0};

--- a/tools/particle_sim.cpp
+++ b/tools/particle_sim.cpp
@@ -34,7 +34,7 @@ void initialize() {
 }
 
 void surf_dist() {
-  surface_intersection_ = xdg_->ray_fire(volume_, r_, u_, INFTY, &history_);
+  surface_intersection_ = xdg_->ray_fire(volume_, r_, u_, INFTY, HitOrientation::EXITING, &history_);
   if (surface_intersection_.first == 0.0) {
     fatal_error("Particle {} stuck at position ({}, {}, {}) on surfacce {}", id_, r_.x, r_.y, r_.z, surface_intersection_.second);
     alive_ = false;


### PR DESCRIPTION
Resolving issue #42 by adding the ability to specify an orientation to the `ray_fire` call by passing an explicit `HitOrientation` enum.
```

  std::pair<double, MeshID> ray_fire(TreeID scene,
                                     const Position& origin,
                                     const Direction& direction,
                                     const double dist_limit = INFTY,
                                     std::vector<MeshID>* const exclude_primitives = nullptr,
                                     HitOrientation orientation = HitOrientation::EXITING);
```
Default value is `EXITING` as most queries will be exiting I assume?

Added some asserts to the `test_ray_fire.cpp` file for using `ray_fire` with a ray orientation specifying whether or not the ray is querying for a `ENTERING` or `EXITING` intersection. Diagram of the rays being tested for below:

![image](https://github.com/user-attachments/assets/2ef767f7-1418-4ef9-8cca-537e74b95351)

@pshriwise Am I missing anything else or is this working as expected?