### PR TITLE
Method nomenclature

### DIFF
--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -292,7 +292,7 @@ public:
 
   // sideset face mapping, stores the element and the side number
   // for each face in the mesh that lies on a boundary
-  std::unordered_map<MeshID, std::vector<MeshID>> sideset_element_map_;
+  std::unordered_map<MeshID, std::vector<MeshID>> sideset_face_map_;
 
   //! Mapping of subdomain interfaces (Identified by subdomain ID pairs) to the
   //! set of element faces that make up the interface

--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -95,7 +95,7 @@ public:
 
   std::vector<Vertex> element_vertices(MeshID element) const override;
 
-  std::array<Vertex, 3> triangle_vertices(MeshID triangle) const override;
+  std::array<Vertex, 3> face_vertices(MeshID triangle) const override;
 
   std::vector<MeshID> get_volume_surfaces(MeshID volume) const override;
 

--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -77,6 +77,10 @@ public:
     }
   }
 
+  int num_volume_elements(MeshID volume) const override {
+    return get_volume_elements(volume).size();
+  }
+
   int num_volume_faces(MeshID volume) const override {
     return mesh()->n_elem();
   }

--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -85,7 +85,7 @@ public:
     return mesh()->n_elem();
   }
 
-  std::vector<MeshID> get_volume_elements(MeshID volume) const override;
+  std::vector<MeshID> get_volume_elements(MeshID volume) const;
 
   std::vector<MeshID> get_surface_faces(MeshID surface) const override;
 

--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -87,7 +87,7 @@ public:
 
   std::vector<MeshID> get_volume_elements(MeshID volume) const override;
 
-  std::vector<MeshID> get_surface_elements(MeshID surface) const override;
+  std::vector<MeshID> get_surface_faces(MeshID surface) const override;
 
   std::vector<Vertex> element_vertices(MeshID element) const override;
 

--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -77,11 +77,11 @@ public:
     }
   }
 
-  int num_volume_elements(MeshID volume) const override {
+  int num_volume_faces(MeshID volume) const override {
     return mesh()->n_elem();
   }
 
-  int num_surface_elements(MeshID surface) const override {
+  int num_surface_faces(MeshID surface) const override {
     return mesh()->n_elem();
   }
 

--- a/include/xdg/mesh_manager_interface.h
+++ b/include/xdg/mesh_manager_interface.h
@@ -29,9 +29,13 @@ public:
   virtual int num_ents_of_dimension(int dim) const = 0;
 
   // Mesh
+  virtual int num_volume_elements(MeshID volume) const = 0;
+
   virtual int num_volume_faces(MeshID volume) const = 0;
 
   virtual int num_surface_faces(MeshID surface) const = 0;
+
+  virtual std::vector<MeshID> get_volume_elements(MeshID volume) const = 0;
 
   virtual std::vector<MeshID> get_volume_faces(MeshID volume) const;
 

--- a/include/xdg/mesh_manager_interface.h
+++ b/include/xdg/mesh_manager_interface.h
@@ -37,24 +37,24 @@ public:
 
   virtual std::vector<MeshID> get_volume_elements(MeshID volume) const = 0;
 
-  virtual std::vector<MeshID> get_volume_faces(MeshID volume) const;
+  std::vector<MeshID> get_volume_faces(MeshID volume) const;
 
   virtual std::vector<MeshID> get_surface_faces(MeshID surface) const = 0;
 
   // TODO: can we accomplish this without allocating memory?
   virtual std::vector<Vertex> element_vertices(MeshID element) const = 0;
 
-  virtual std::array<Vertex, 3> triangle_vertices(MeshID element) const = 0;
+  virtual std::array<Vertex, 3> face_vertices(MeshID element) const = 0;
 
   BoundingBox element_bounding_box(MeshID element) const;
 
-  BoundingBox triangle_bounding_box(MeshID element) const;
+  BoundingBox face_bounding_box(MeshID element) const;
 
   BoundingBox volume_bounding_box(MeshID volume) const;
 
   BoundingBox surface_bounding_box(MeshID surface) const;
 
-  Direction triangle_normal(MeshID element) const;
+  Direction face_normal(MeshID element) const;
 
   // Topology
   // Returns parent with forward sense, then reverse

--- a/include/xdg/mesh_manager_interface.h
+++ b/include/xdg/mesh_manager_interface.h
@@ -35,7 +35,7 @@ public:
 
   virtual std::vector<MeshID> get_volume_elements(MeshID volume) const = 0;
 
-  virtual std::vector<MeshID> get_surface_elements(MeshID surface) const = 0;
+  virtual std::vector<MeshID> get_surface_faces(MeshID surface) const = 0;
 
   // TODO: can we accomplish this without allocating memory?
   virtual std::vector<Vertex> element_vertices(MeshID element) const = 0;

--- a/include/xdg/mesh_manager_interface.h
+++ b/include/xdg/mesh_manager_interface.h
@@ -29,9 +29,9 @@ public:
   virtual int num_ents_of_dimension(int dim) const = 0;
 
   // Mesh
-  virtual int num_volume_elements(MeshID volume) const = 0;
+  virtual int num_volume_faces(MeshID volume) const = 0;
 
-  virtual int num_surface_elements(MeshID surface) const = 0;
+  virtual int num_surface_faces(MeshID surface) const = 0;
 
   virtual std::vector<MeshID> get_volume_faces(MeshID volume) const;
 

--- a/include/xdg/mesh_manager_interface.h
+++ b/include/xdg/mesh_manager_interface.h
@@ -33,7 +33,7 @@ public:
 
   virtual int num_surface_elements(MeshID surface) const = 0;
 
-  virtual std::vector<MeshID> get_volume_elements(MeshID volume) const = 0;
+  virtual std::vector<MeshID> get_volume_faces(MeshID volume) const;
 
   virtual std::vector<MeshID> get_surface_faces(MeshID surface) const = 0;
 

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -54,8 +54,6 @@ public:
 
   int num_surface_elements(MeshID surface) const override;
 
-  std::vector<MeshID> get_volume_elements(MeshID volume) const override;
-
   std::vector<MeshID> get_surface_faces(MeshID surface) const override;
 
   std::vector<Vertex> element_vertices(MeshID element) const override;

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -62,7 +62,7 @@ public:
 
   std::vector<Vertex> element_vertices(MeshID element) const override;
 
-  std::array<Vertex, 3> triangle_vertices(MeshID element) const override;
+  std::array<Vertex, 3> face_vertices(MeshID element) const override;
 
   // Topology
   std::pair<MeshID, MeshID> surface_senses(MeshID surface) const override;

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -56,7 +56,7 @@ public:
 
   std::vector<MeshID> get_volume_elements(MeshID volume) const override;
 
-  std::vector<MeshID> get_surface_elements(MeshID surface) const override;
+  std::vector<MeshID> get_surface_faces(MeshID surface) const override;
 
   std::vector<Vertex> element_vertices(MeshID element) const override;
 

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -50,9 +50,13 @@ public:
   void add_surface_to_volume(MeshID volume, MeshID surface, Sense sense, bool overwrite=false) override;
 
   // Mesh
+  int num_volume_elements(MeshID volume) const override;
+
   int num_volume_faces(MeshID volume) const override;
 
   int num_surface_faces(MeshID surface) const override;
+
+  std::vector<MeshID> get_volume_elements(MeshID volume) const override;
 
   std::vector<MeshID> get_surface_faces(MeshID surface) const override;
 

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -78,7 +78,7 @@ public:
 private:
   // Internal MOAB methods
   std::vector<moab::EntityHandle> _ents_of_dim(int dim) const;
-  moab::Range _surface_elements(MeshID surface) const;
+  moab::Range _surface_faces(MeshID surface) const;
 
   std::string get_volume_property(const std::string& property, MeshID vol) const;
 

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -50,9 +50,9 @@ public:
   void add_surface_to_volume(MeshID volume, MeshID surface, Sense sense, bool overwrite=false) override;
 
   // Mesh
-  int num_volume_elements(MeshID volume) const override;
+  int num_volume_faces(MeshID volume) const override;
 
-  int num_surface_elements(MeshID surface) const override;
+  int num_surface_faces(MeshID surface) const override;
 
   std::vector<MeshID> get_surface_faces(MeshID surface) const override;
 

--- a/src/embree/ray_tracer.cpp
+++ b/src/embree/ray_tracer.cpp
@@ -42,7 +42,7 @@ EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager
   auto volume_scene = this->create_embree_scene();
 
   // allocate storage for this volume
-  auto volume_elements = mesh_manager->get_volume_elements(volume_id);
+  auto volume_elements = mesh_manager->get_volume_faces(volume_id);
   this->primitive_ref_storage_[volume_scene].resize(volume_elements.size());
   auto& triangle_storage = this->primitive_ref_storage_[volume_scene];
 
@@ -56,7 +56,7 @@ EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager
     else if (volume_id == surf_to_vol_senses.second) triangle_sense = Sense::REVERSE;
     else fatal_error("Volume {} is not a parent of surface {}", volume_id, surface_id);
 
-    auto surface_elements = mesh_manager->get_surface_elements(surface_id);
+    auto surface_elements = mesh_manager->get_surface_faces(surface_id);
     for (int i = 0; i < surface_elements.size(); ++i) {
       auto& primitive_ref = triangle_storage[i + storage_offset];
       primitive_ref.primitive_id = surface_elements[i];
@@ -81,7 +81,7 @@ EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager
   // create a new geometry for each surface
   int buffer_start = 0;
   for (auto surface : volume_surfaces) {
-    auto surface_triangles = mesh_manager->get_surface_elements(surface);
+    auto surface_triangles = mesh_manager->get_surface_faces(surface);
     RTCGeometry surface_geometry = rtcNewGeometry(device_, RTC_GEOMETRY_TYPE_USER);
     rtcSetGeometryUserPrimitiveCount(surface_geometry, surface_triangles.size());
     unsigned int embree_surface = rtcAttachGeometry(volume_scene, surface_geometry);

--- a/src/embree/ray_tracer.cpp
+++ b/src/embree/ray_tracer.cpp
@@ -42,8 +42,8 @@ EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager
   auto volume_scene = this->create_embree_scene();
 
   // allocate storage for this volume
-  auto volume_elements = mesh_manager->get_volume_faces(volume_id);
-  this->primitive_ref_storage_[volume_scene].resize(volume_elements.size());
+  auto volume_faces = mesh_manager->get_volume_faces(volume_id);
+  this->primitive_ref_storage_[volume_scene].resize(volume_faces.size());
   auto& triangle_storage = this->primitive_ref_storage_[volume_scene];
 
   auto volume_surfaces = mesh_manager->get_volume_surfaces(volume_id);
@@ -56,13 +56,13 @@ EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager
     else if (volume_id == surf_to_vol_senses.second) triangle_sense = Sense::REVERSE;
     else fatal_error("Volume {} is not a parent of surface {}", volume_id, surface_id);
 
-    auto surface_elements = mesh_manager->get_surface_faces(surface_id);
-    for (int i = 0; i < surface_elements.size(); ++i) {
+    auto surface_faces = mesh_manager->get_surface_faces(surface_id);
+    for (int i = 0; i < surface_faces.size(); ++i) {
       auto& primitive_ref = triangle_storage[i + storage_offset];
-      primitive_ref.primitive_id = surface_elements[i];
+      primitive_ref.primitive_id = surface_faces[i];
       primitive_ref.sense = triangle_sense;
     }
-    storage_offset += surface_elements.size();
+    storage_offset += surface_faces.size();
  }
 
   PrimitiveRef* tri_ref_ptr = triangle_storage.data();

--- a/src/libmesh/mesh_manager.cpp
+++ b/src/libmesh/mesh_manager.cpp
@@ -334,7 +334,7 @@ LibMeshManager::get_volume_elements(MeshID volume) const {
 }
 
 std::vector<MeshID>
-LibMeshManager::get_surface_elements(MeshID surface) const {
+LibMeshManager::get_surface_faces(MeshID surface) const {
   return surface_map_.at(surface);
 }
 

--- a/src/libmesh/mesh_manager.cpp
+++ b/src/libmesh/mesh_manager.cpp
@@ -69,7 +69,7 @@ void LibMeshManager::init() {
   // the elements associated with each sideset
   for (auto entry : boundary_info.get_sideset_map()) {
     const libMesh::Elem* other_elem = entry.first->neighbor_ptr(entry.second.first);
-    sideset_element_map_[entry.second.second].push_back(sidepair_id({entry.first, entry.second.first}));
+    sideset_face_map_[entry.second.second].push_back(sidepair_id({entry.first, entry.second.first}));
   }
 
   // search for any implicit sidesets (faces that are the boundary between two
@@ -191,7 +191,7 @@ void LibMeshManager::merge_sidesets_into_interfaces() {
   // Partial replacement is allowed. If any elements remain in the
   // interface sets after this operation, they will be treated as interfaces
   // between subdomains
-  for (const auto& [sideset_id, sideset_elems] : sideset_element_map_) {
+  for (const auto& [sideset_id, sideset_elems] : sideset_face_map_) {
     if (sideset_elems.size() == 0) continue;
 
     // determine the subdomain IDs for the sideset
@@ -230,7 +230,7 @@ void LibMeshManager::merge_sidesets_into_interfaces() {
 void LibMeshManager::create_surfaces_from_sidesets_and_interfaces() {
   // start by creating surfaces for each sideset. These have explicit IDs
   // and may be used to define boundary conditions.
-  for (const auto& [sideset_id, sideset_elems] : sideset_element_map_) {
+  for (const auto& [sideset_id, sideset_elems] : sideset_face_map_) {
     surfaces().push_back(sideset_id);
     for (const auto& elem : sideset_elems) {
       surface_map_[sideset_id].push_back(elem);

--- a/src/libmesh/mesh_manager.cpp
+++ b/src/libmesh/mesh_manager.cpp
@@ -338,7 +338,8 @@ LibMeshManager::get_surface_faces(MeshID surface) const {
   return surface_map_.at(surface);
 }
 
-std::vector<Vertex> LibMeshManager::element_vertices(MeshID element) const {
+std::vector<Vertex>
+LibMeshManager::element_vertices(MeshID element) const {
   std::vector<Vertex> vertices;
   auto elem = mesh()->elem_ptr(element);
   for (unsigned int i = 0; i < elem->n_nodes(); ++i) {
@@ -349,7 +350,7 @@ std::vector<Vertex> LibMeshManager::element_vertices(MeshID element) const {
 }
 
 std::array<Vertex, 3>
-LibMeshManager::triangle_vertices(MeshID element) const {
+LibMeshManager::face_vertices(MeshID element) const {
   const auto& side_pair = sidepair(element);
   std::array<Vertex, 3> vertices;
   for (unsigned int i = 0; i < 3; ++i) {

--- a/src/mesh_manager_interface.cpp
+++ b/src/mesh_manager_interface.cpp
@@ -118,7 +118,7 @@ MeshManager::volume_bounding_box(MeshID volume) const
 BoundingBox
 MeshManager::surface_bounding_box(MeshID surface) const
 {
-  auto elements = this->get_surface_elements(surface);
+  auto elements = this->get_surface_faces(surface);
   BoundingBox bb;
   for (const auto& element : elements) {
     bb.update(this->element_bounding_box(element));

--- a/src/mesh_manager_interface.cpp
+++ b/src/mesh_manager_interface.cpp
@@ -96,9 +96,9 @@ MeshID MeshManager::next_volume(MeshID current_volume, MeshID surface) const
   return ID_NONE;
 }
 
-Direction MeshManager::triangle_normal(MeshID element) const
+Direction MeshManager::face_normal(MeshID element) const
 {
-  auto vertices = this->triangle_vertices(element);
+  auto vertices = this->face_vertices(element);
   return (vertices[1] - vertices[0]).cross(vertices[2] - vertices[0]).normalize();
 }
 
@@ -110,9 +110,9 @@ MeshManager::element_bounding_box(MeshID element) const
 }
 
 BoundingBox
-MeshManager::triangle_bounding_box(MeshID element) const
+MeshManager::face_bounding_box(MeshID element) const
 {
-  auto vertices = this->triangle_vertices(element);
+  auto vertices = this->face_vertices(element);
   return BoundingBox::from_points(vertices);
 }
 

--- a/src/mesh_manager_interface.cpp
+++ b/src/mesh_manager_interface.cpp
@@ -1,6 +1,7 @@
 #include "xdg/mesh_manager_interface.h"
 
 #include <algorithm>
+#include <set>
 
 #include "xdg/error.h"
 
@@ -48,6 +49,17 @@ bool
 MeshManager::volume_has_property(MeshID volume, PropertyType type) const
 {
   return volume_metadata_.count({volume, type}) > 0;
+}
+
+std::vector<MeshID>
+MeshManager::get_volume_faces(MeshID volume) const
+{
+  std::set<MeshID> elements;
+  for (auto surface : this->get_volume_surfaces(volume)) {
+    auto surface_elements = this->get_surface_faces(surface);
+    elements.insert(surface_elements.begin(), surface_elements.end());
+  }
+  return std::vector<MeshID>(elements.begin(), elements.end());
 }
 
 bool

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -147,6 +147,12 @@ MOABMeshManager::_surface_faces(MeshID surface) const
 }
 
 int
+MOABMeshManager::num_volume_elements(MeshID volume) const
+{
+  return this->get_volume_elements(volume).size();
+}
+
+int
 MOABMeshManager::num_volume_faces(MeshID volume) const
 {
   int out {0};
@@ -160,6 +166,21 @@ int
 MOABMeshManager::num_surface_faces(MeshID surface) const
 {
   return this->_surface_faces(surface).size();
+}
+
+std::vector<MeshID>
+MOABMeshManager::get_volume_elements(MeshID volume) const
+{
+  moab::EntityHandle vol_handle = volume_id_map_.at(volume);
+
+  moab::Range elements;
+  this->moab_interface()->get_entities_by_dimension(vol_handle, 3, elements);
+
+  std::vector<MeshID> element_ids(elements.size());
+  for (int i = 0; i < elements.size(); i++) {
+    element_ids[i] = this->moab_interface()->id_from_handle(elements[i]);
+  }
+  return element_ids;
 }
 
 std::vector<MeshID>

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -163,16 +163,6 @@ MOABMeshManager::num_surface_elements(MeshID surface) const
 }
 
 std::vector<MeshID>
-MOABMeshManager::get_volume_elements(MeshID volume) const
-{
-  moab::Range elements;
-  for (auto surface : this->get_volume_surfaces(volume)) {
-    elements.merge(this->_surface_elements(surface));
-  }
-  return std::vector<MeshID>(elements.begin(), elements.end());
-}
-
-std::vector<MeshID>
 MOABMeshManager::get_surface_faces(MeshID surface) const
 {
   auto elements = this->_surface_elements(surface);

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -147,17 +147,17 @@ MOABMeshManager::_surface_elements(MeshID surface) const
 }
 
 int
-MOABMeshManager::num_volume_elements(MeshID volume) const
+MOABMeshManager::num_volume_faces(MeshID volume) const
 {
   int out {0};
   for (auto surface : this->get_volume_surfaces(volume)) {
-    out += this->num_surface_elements(surface);
+    out += this->num_surface_faces(surface);
   }
   return out;
 }
 
 int
-MOABMeshManager::num_surface_elements(MeshID surface) const
+MOABMeshManager::num_surface_faces(MeshID surface) const
 {
   return this->_surface_elements(surface).size();
 }

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -173,7 +173,7 @@ MOABMeshManager::get_volume_elements(MeshID volume) const
 }
 
 std::vector<MeshID>
-MOABMeshManager::get_surface_elements(MeshID surface) const
+MOABMeshManager::get_surface_faces(MeshID surface) const
 {
   auto elements = this->_surface_elements(surface);
 

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -205,7 +205,7 @@ std::vector<Vertex> MOABMeshManager::element_vertices(MeshID element) const
   return std::vector<Vertex>(out.begin(), out.end());
 }
 
-std::array<Vertex, 3> MOABMeshManager::triangle_vertices(MeshID element) const
+std::array<Vertex, 3> MOABMeshManager::face_vertices(MeshID element) const
 {
   auto vertices = this->element_vertices(element);
   return {vertices[0], vertices[1], vertices[2]};

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -138,7 +138,7 @@ void MOABMeshManager::add_surface_to_volume(MeshID volume, MeshID surface, Sense
 
 // Mesh Methods
 moab::Range
-MOABMeshManager::_surface_elements(MeshID surface) const
+MOABMeshManager::_surface_faces(MeshID surface) const
 {
   moab::EntityHandle surf_handle = surface_id_map_.at(surface);
   moab::Range elements;
@@ -159,13 +159,13 @@ MOABMeshManager::num_volume_faces(MeshID volume) const
 int
 MOABMeshManager::num_surface_faces(MeshID surface) const
 {
-  return this->_surface_elements(surface).size();
+  return this->_surface_faces(surface).size();
 }
 
 std::vector<MeshID>
 MOABMeshManager::get_surface_faces(MeshID surface) const
 {
-  auto elements = this->_surface_elements(surface);
+  auto elements = this->_surface_faces(surface);
 
   std::vector<MeshID> element_ids(elements.size());
   for (int i = 0; i < elements.size(); i++) {

--- a/src/overlap_check/overlap.cpp
+++ b/src/overlap_check/overlap.cpp
@@ -73,7 +73,7 @@ void check_instance_for_overlaps(std::shared_ptr<XDG> xdg,
      implicit complement as well as the explicit volumes. Also removes an uneccesary layer of nesting. */
 
   for (const auto& surf:allSurfs){  
-    auto surfElements = mm->get_surface_elements(surf);
+    auto surfElements = mm->get_surface_faces(surf);
     totalElements += surfElements.size();
     for (const auto& tri:surfElements){
       auto triVert = mm->triangle_vertices(tri);
@@ -151,7 +151,7 @@ void check_instance_for_overlaps(std::shared_ptr<XDG> xdg,
       {
         return vol != parentVols.first && vol != parentVols.second;
       });
-      auto elementsOnSurf = mm->get_surface_elements(surf);
+      auto elementsOnSurf = mm->get_surface_faces(surf);
       for (const auto& element:elementsOnSurf) {
         auto tri = mm->triangle_vertices(element);
         auto rayQueries = return_ray_queries(tri);

--- a/src/overlap_check/overlap.cpp
+++ b/src/overlap_check/overlap.cpp
@@ -72,11 +72,11 @@ void check_instance_for_overlaps(std::shared_ptr<XDG> xdg,
   /* Loop over surface instead of all volumes as it results in duplicating the number of checks when it does the nodes in the
      implicit complement as well as the explicit volumes. Also removes an uneccesary layer of nesting. */
 
-  for (const auto& surf:allSurfs){  
+  for (const auto& surf:allSurfs){
     auto surfElements = mm->get_surface_faces(surf);
     totalElements += surfElements.size();
     for (const auto& tri:surfElements){
-      auto triVert = mm->triangle_vertices(tri);
+      auto triVert = mm->face_vertices(tri);
       // Push vertices in triangle to end of array
       allVerts.push_back(triVert[0]);
       allVerts.push_back(triVert[1]);
@@ -109,7 +109,7 @@ void check_instance_for_overlaps(std::shared_ptr<XDG> xdg,
     }
   }
 
-  if (overlap_map.empty()) { 
+  if (overlap_map.empty()) {
     std::cout << "No Overlaps found at vertices! \n" << std::endl;
   }
 
@@ -127,13 +127,13 @@ void check_instance_for_overlaps(std::shared_ptr<XDG> xdg,
     return;
   }
 
-  std::cout << "Checking for overlapped regions along element edges..." << std::endl; 
-  
+  std::cout << "Checking for overlapped regions along element edges..." << std::endl;
+
   ProgressBar edgeProgBar;
   std::vector<Position> edgeOverlapLocs;
 
   // Number of rays cast along edges = number_of_elements * (number_of_edges * 2) * (number_of_vols - parent_vols)
-  int totalEdgeRays = totalElements*(3)*(allVols.size()-2); 
+  int totalEdgeRays = totalElements*(3)*(allVols.size()-2);
   int edgeRaysCast = 0;
 
 #pragma omp parallel shared(overlap_map, edgeRaysCast)
@@ -153,12 +153,12 @@ void check_instance_for_overlaps(std::shared_ptr<XDG> xdg,
       });
       auto elementsOnSurf = mm->get_surface_faces(surf);
       for (const auto& element:elementsOnSurf) {
-        auto tri = mm->triangle_vertices(element);
+        auto tri = mm->face_vertices(element);
         auto rayQueries = return_ray_queries(tri);
         for (const auto& query:rayQueries)
         {
           auto volHit = check_along_edge(xdg, mm, query, volsToCheck, edgeOverlapLocs);
-          if (volHit != -1) 
+          if (volHit != -1)
           {
             overlap_map[{volHit, parentVols.first}] = edgeOverlapLocs.back();
           }
@@ -171,7 +171,7 @@ void check_instance_for_overlaps(std::shared_ptr<XDG> xdg,
     }
   }
 
-  if (overlap_map.empty()) { 
+  if (overlap_map.empty()) {
     std::cout << "No Overlaps found along edges! \n" << std::endl;
   }
 
@@ -203,8 +203,8 @@ void report_overlaps(const OverlapMap& overlap_map) {
   }
 }
 
-/* Return rayQueries along element edges. Currently limited to Triangles as ElementVertices is defined as a std::array<xdg::vertex, 3> 
-   but the rest of the function body could easily work with a container of any size so could readily be generalised 
+/* Return rayQueries along element edges. Currently limited to Triangles as ElementVertices is defined as a std::array<xdg::vertex, 3>
+   but the rest of the function body could easily work with a container of any size so could readily be generalised
    to work with quads. */
 std::vector<EdgeRayQuery> return_ray_queries(const ElementVertices &element)
 {
@@ -216,9 +216,9 @@ std::vector<EdgeRayQuery> return_ray_queries(const ElementVertices &element)
     const auto& v1 = element[vertex];
     const auto& v2 = element[nextVertex];
 
-    Direction dir = v2 - v1;    
+    Direction dir = v2 - v1;
     double edgeLength = dir.length();
-    dir /= edgeLength; 
+    dir /= edgeLength;
 
     // Add the edge ray query
     rayQueries.push_back({v1, dir, edgeLength});
@@ -227,10 +227,10 @@ std::vector<EdgeRayQuery> return_ray_queries(const ElementVertices &element)
 }
 
 // Fire a ray along a single edge direction firing against all volumes except for the current surfaces' parent volumes (fowards+reverse sense). Returns volume ID of the surface hit
-MeshID check_along_edge(std::shared_ptr<XDG> xdg, 
-                        std::shared_ptr<MeshManager> mm, 
-                        const EdgeRayQuery& rayquery, 
-                        const std::vector<MeshID>& volsToCheck, 
+MeshID check_along_edge(std::shared_ptr<XDG> xdg,
+                        std::shared_ptr<MeshManager> mm,
+                        const EdgeRayQuery& rayquery,
+                        const std::vector<MeshID>& volsToCheck,
                         std::vector<Position>& edgeOverlapLocs)
 {
   auto origin = rayquery.origin;
@@ -240,7 +240,7 @@ MeshID check_along_edge(std::shared_ptr<XDG> xdg,
   int counter=0;
   for (const auto& testVol:volsToCheck)
   {
-    auto ray = xdg->ray_fire(testVol, origin, direction, distanceMax); 
+    auto ray = xdg->ray_fire(testVol, origin, direction, distanceMax);
     double rayDistance = ray.first;
     MeshID surfHit = ray.second;
     if (surfHit != -1) // if surface hit (Valid MeshID returned)
@@ -248,7 +248,7 @@ MeshID check_along_edge(std::shared_ptr<XDG> xdg,
       counter++;
       volHit = mm->get_parent_volumes(surfHit);
 
-      Position collisionPoint = {origin.x + rayDistance*direction.x, origin.y + rayDistance*direction.y, origin.z + rayDistance*direction.z}; 
+      Position collisionPoint = {origin.x + rayDistance*direction.x, origin.y + rayDistance*direction.y, origin.z + rayDistance*direction.z};
       // Check if overlap location already added to list from another ray
       if (std::find(edgeOverlapLocs.begin(), edgeOverlapLocs.end(), collisionPoint) == edgeOverlapLocs.end()) {
         edgeOverlapLocs.push_back(collisionPoint);

--- a/src/ray_tracing_interface.cpp
+++ b/src/ray_tracing_interface.cpp
@@ -43,7 +43,7 @@ RayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
   auto volume_scene = this->create_scene();
 
   // allocate storage for this volume
-  auto volume_elements = mesh_manager->get_volume_elements(volume_id);
+  auto volume_elements = mesh_manager->get_volume_faces(volume_id);
   this->primitive_ref_storage_[volume_scene].resize(volume_elements.size());
   auto& triangle_storage = this->primitive_ref_storage_[volume_scene];
 

--- a/src/ray_tracing_interface.cpp
+++ b/src/ray_tracing_interface.cpp
@@ -57,7 +57,7 @@ RayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
     else if (volume_id == surf_to_vol_senses.second) triangle_sense = Sense::REVERSE;
     else fatal_error("Volume {} is not a parent of surface {}", volume_id, surface_id);
 
-    auto surface_elements = mesh_manager->get_surface_elements(surface_id);
+    auto surface_elements = mesh_manager->get_surface_faces(surface_id);
     for (int i = 0; i < surface_elements.size(); ++i) {
       auto& primitive_ref = triangle_storage[i + storage_offset];
       primitive_ref.primitive_id = surface_elements[i];
@@ -84,7 +84,7 @@ RayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
   // create a new geometry for each surface
   int buffer_start = 0;
   for (auto surface : volume_surfaces) {
-    auto surface_triangles = mesh_manager->get_surface_elements(surface);
+    auto surface_triangles = mesh_manager->get_surface_faces(surface);
     RTCGeometry surface_geometry = rtcNewGeometry(device_, RTC_GEOMETRY_TYPE_USER);
     rtcSetGeometryUserPrimitiveCount(surface_geometry, surface_triangles.size());
     unsigned int embree_surface = rtcAttachGeometry(volume_scene, surface_geometry);

--- a/src/triangle_intersect.cpp
+++ b/src/triangle_intersect.cpp
@@ -40,7 +40,7 @@ void TriangleBoundsFunc(RTCBoundsFunctionArguments* args)
   const MeshManager* mesh_manager = user_data->mesh_manager;
 
   const PrimitiveRef& primitive_ref = user_data->prim_ref_buffer[args->primID];
-  BoundingBox bounds = mesh_manager->triangle_bounding_box(primitive_ref.primitive_id);
+  BoundingBox bounds = mesh_manager->face_bounding_box(primitive_ref.primitive_id);
 
   args->bounds_o->lower_x = bounds.min_x - user_data->box_bump;
   args->bounds_o->lower_y = bounds.min_y - user_data->box_bump;
@@ -56,7 +56,7 @@ void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
 
   const PrimitiveRef& primitive_ref = user_data->prim_ref_buffer[args->primID];
 
-  auto vertices = mesh_manager->triangle_vertices(primitive_ref.primitive_id);
+  auto vertices = mesh_manager->face_vertices(primitive_ref.primitive_id);
 
   RTCDRayHit* rayhit = (RTCDRayHit*)args->rayhit;
   RTCDRay& ray = rayhit->ray;
@@ -73,7 +73,7 @@ void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
 
   if (plucker_dist > rayhit->ray.dtfar) return;
 
-  Direction normal = mesh_manager->triangle_normal(primitive_ref.primitive_id);
+  Direction normal = mesh_manager->face_normal(primitive_ref.primitive_id);
   // if this is a normal ray fire, flip the normal as needed
   if (primitive_ref.sense == Sense::REVERSE && rayhit->ray.rf_type != RayFireType::FIND_VOLUME)
     normal = -normal;
@@ -107,7 +107,7 @@ bool TriangleClosestFunc(RTCPointQueryFunctionArguments* args) {
   const MeshManager* mesh_manager = user_data->mesh_manager;
 
   const PrimitiveRef& primitive_ref = user_data->prim_ref_buffer[args->primID];
-  auto vertices = mesh_manager->triangle_vertices(primitive_ref.primitive_id);
+  auto vertices = mesh_manager->face_vertices(primitive_ref.primitive_id);
 
   RTCDPointQuery* query = (RTCDPointQuery*) args->query;
   Position p {query->dblx, query->dbly, query->dblz};
@@ -132,7 +132,7 @@ void TriangleOcclusionFunc(RTCOccludedFunctionNArguments* args) {
   const MeshManager* mesh_manager = user_data->mesh_manager;
   const PrimitiveRef& primitive_ref = user_data->prim_ref_buffer[args->primID];
 
-  auto vertices = mesh_manager->triangle_vertices(primitive_ref.primitive_id);
+  auto vertices = mesh_manager->face_vertices(primitive_ref.primitive_id);
 
   // get the double precision ray from the args
   RTCDRay* ray = (RTCDRay*) args->ray;

--- a/src/xdg.cpp
+++ b/src/xdg.cpp
@@ -156,7 +156,7 @@ double XDG::measure_volume(MeshID volume) const
   for (int i = 0; i < surfaces.size(); ++i) {
     MeshID& surface = surfaces[i];
     double surface_contribution {0.0};
-    auto triangles = mesh_manager()->get_surface_elements(surface);
+    auto triangles = mesh_manager()->get_surface_faces(surface);
     for (auto triangle : triangles) {
       surface_contribution += triangle_volume_contribution(mesh_manager()->triangle_vertices(triangle));
     }
@@ -170,7 +170,7 @@ double XDG::measure_volume(MeshID volume) const
 double XDG::measure_surface_area(MeshID surface) const
 {
   double area {0.0};
-  for (auto triangle : mesh_manager()->get_surface_elements(surface)) {
+  for (auto triangle : mesh_manager()->get_surface_faces(surface)) {
     area += triangle_area(mesh_manager()->triangle_vertices(triangle));
   }
   return area;

--- a/src/xdg.cpp
+++ b/src/xdg.cpp
@@ -139,7 +139,7 @@ Direction XDG::surface_normal(MeshID surface,
     //   fatal_error("Point {} was closest to surface {}, not surface {}, in volume {}.", point, geom_data.surface_id, surface, surface_vols.first);
     // }
   }
-  return mesh_manager()->triangle_normal(element);
+  return mesh_manager()->face_normal(element);
 }
 
 double XDG::measure_volume(MeshID volume) const
@@ -158,7 +158,7 @@ double XDG::measure_volume(MeshID volume) const
     double surface_contribution {0.0};
     auto triangles = mesh_manager()->get_surface_faces(surface);
     for (auto triangle : triangles) {
-      surface_contribution += triangle_volume_contribution(mesh_manager()->triangle_vertices(triangle));
+      surface_contribution += triangle_volume_contribution(mesh_manager()->face_vertices(triangle));
     }
     if (surface_senses[i] == Sense::REVERSE) surface_contribution *= -1.0;
     volume_total += surface_contribution;
@@ -171,7 +171,7 @@ double XDG::measure_surface_area(MeshID surface) const
 {
   double area {0.0};
   for (auto triangle : mesh_manager()->get_surface_faces(surface)) {
-    area += triangle_area(mesh_manager()->triangle_vertices(triangle));
+    area += triangle_area(mesh_manager()->face_vertices(triangle));
   }
   return area;
 }

--- a/tests/mesh_mock.h
+++ b/tests/mesh_mock.h
@@ -56,7 +56,7 @@ public:
     return {0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ,10, 11};
   }
 
-  virtual std::vector<MeshID> get_surface_elements(MeshID surface) const override {
+  virtual std::vector<MeshID> get_surface_faces(MeshID surface) const override {
     int start = surface * 2;
     return {start, start + 1};
   }

--- a/tests/mesh_mock.h
+++ b/tests/mesh_mock.h
@@ -44,11 +44,11 @@ public:
     return -1;
   }
 
-  virtual int num_volume_elements(MeshID volume) const override {
+  virtual int num_volume_faces(MeshID volume) const override {
     return 12;
   }
 
-  virtual int num_surface_elements(MeshID surface) const override {
+  virtual int num_surface_faces(MeshID surface) const override {
     return 2;
   }
 

--- a/tests/mesh_mock.h
+++ b/tests/mesh_mock.h
@@ -44,12 +44,20 @@ public:
     return -1;
   }
 
+  virtual int num_volume_elements(MeshID volume) const override {
+    return 0;
+  }
+
   virtual int num_volume_faces(MeshID volume) const override {
     return 12;
   }
 
   virtual int num_surface_faces(MeshID surface) const override {
     return 2;
+  }
+
+  virtual std::vector<MeshID> get_volume_elements(MeshID volume) const override {
+    return {0};
   }
 
   virtual std::vector<MeshID> get_volume_faces(MeshID volume) const override {

--- a/tests/mesh_mock.h
+++ b/tests/mesh_mock.h
@@ -52,7 +52,7 @@ public:
     return 2;
   }
 
-  virtual std::vector<MeshID> get_volume_elements(MeshID volume) const override {
+  virtual std::vector<MeshID> get_volume_faces(MeshID volume) const override {
     return {0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ,10, 11};
   }
 

--- a/tests/mesh_mock.h
+++ b/tests/mesh_mock.h
@@ -60,10 +60,6 @@ public:
     return {0};
   }
 
-  virtual std::vector<MeshID> get_volume_faces(MeshID volume) const override {
-    return {0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ,10, 11};
-  }
-
   virtual std::vector<MeshID> get_surface_faces(MeshID surface) const override {
     int start = surface * 2;
     return {start, start + 1};
@@ -74,7 +70,7 @@ public:
     return {vertices[conn[0]], vertices[conn[1]], vertices[conn[2]]};
   }
 
-  virtual std::array<Vertex, 3> triangle_vertices(MeshID element) const override {
+  virtual std::array<Vertex, 3> face_vertices(MeshID element) const override {
     const auto vertices = element_vertices(element);
     return {vertices[0], vertices[1], vertices[2]};
   }

--- a/tests/particle_sim.h
+++ b/tests/particle_sim.h
@@ -1,1 +1,151 @@
-../tools/particle_sim.h
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "xdg/error.h"
+#include "xdg/mesh_manager_interface.h"
+#include "xdg/vec3da.h"
+#include "xdg/xdg.h"
+
+using namespace xdg;
+
+struct SimulationData {
+  std::shared_ptr<XDG> xdg_;
+  double mfp_ {1.0};
+  uint32_t n_particles_ {100};
+  uint32_t max_events_ {1000};
+  bool verbose_particles_ {false};
+  std::unordered_map<MeshID, double> cell_tracks;
+};
+
+struct Particle {
+
+Particle(std::shared_ptr<XDG> xdg, uint32_t id, uint32_t max_events, bool verbose=true) : verbose_(verbose), xdg_(xdg), id_(id), max_events_(max_events) {}
+
+template<typename... Params>
+void log (const std::string& msg, const Params&... fmt_args) {
+  if (!verbose_) return;
+  write_message(msg, fmt_args...);
+}
+
+void initialize() {
+  // TODO: replace with sampling
+  r_ = {0.0, 0.0, 0.0};
+  u_ = {1.0, 0.0, 0.0};
+
+  volume_ = xdg_->find_volume(r_, u_);
+  log("Particle {} initialized in volume {}", id_, volume_);
+}
+
+void surf_dist() {
+  surface_intersection_ = xdg_->ray_fire(volume_, r_, u_, INFTY, HitOrientation::EXITING, &history_);
+  if (surface_intersection_.first == 0.0) {
+    fatal_error("Particle {} stuck at position ({}, {}, {}) on surfacce {}", id_, r_.x, r_.y, r_.z, surface_intersection_.second);
+    alive_ = false;
+    return;
+  }
+  if (surface_intersection_.second == ID_NONE) {
+    fatal_error("Particle {} lost in volume {}", id_, volume_);
+    alive_ = false;
+    return;
+  }
+  log("Intersected surface {} at distance {} ", surface_intersection_.second, surface_intersection_.first);
+}
+
+void sample_collision_distance(double mfp) {
+  collision_distance_ = -std::log(1.0 - drand48()) * mfp;
+}
+
+void collide() {
+  n_events_++;
+  log("Event {} for particle {}", n_events_, id_);
+  u_ = rand_dir();
+  log("Particle {} collides with material at position ({}, {}, {}), new direction is ({}, {}, {})", id_, r_.x, r_.y, r_.z, u_.z, u_.y, u_.z);
+  history_.clear();
+}
+
+void advance(std::unordered_map<MeshID, double>& cell_tracks)
+{
+  log("Comparing surface intersection distance {} to collision distance {}", surface_intersection_.first, collision_distance_);
+  if (collision_distance_ < surface_intersection_.first) {
+    r_ += collision_distance_ * u_;
+    cell_tracks[volume_] += collision_distance_;
+    log("Particle {} collides with material at position ({}, {}, {}) ", id_, r_.x, r_.y, r_.z);
+  } else {
+    r_ += surface_intersection_.first * u_;
+    cell_tracks[volume_] += surface_intersection_.first;
+    log("Particle {} advances to surface {} at position ({}, {}, {}) ", id_, surface_intersection_.second, r_.x, r_.y, r_.z);
+  }
+}
+
+void cross_surface()
+{
+  n_events_++;
+  log("Event {} for particle {}", n_events_, id_);
+  auto boundary_condition = xdg_->mesh_manager()->get_surface_property(surface_intersection_.second, PropertyType::BOUNDARY_CONDITION);
+  // check for the surface boundary condition
+  if (boundary_condition.value == "reflecting" || boundary_condition.value == "reflective") {
+    log("Particle {} reflects off surface {}", id_, surface_intersection_.second);
+    log("Direction before reflection: ({}, {}, {})", u_.x, u_.y, u_.z);
+
+    Direction normal = xdg_->surface_normal(surface_intersection_.second, r_, &history_);
+    log("Normal to surface: ({}, {}, {})", normal.x, normal.y, normal.z);
+
+    double proj = dot(normal, u_);
+    double mag = normal.length();
+    normal = normal * (2.0 * proj/mag);
+    u_ = u_ - normal;
+    u_ = u_.normalize();
+    log("Direction after reflection: ({}, {}, {})", u_.x, u_.y, u_.z);
+    // reset to last intersection
+    if (history_.size() > 0) {
+      log("Resetting particle history to last intersection");
+      history_ = {history_.back()};
+    }
+  } else if (boundary_condition.value == "vacuum") {
+    log("Particle {} encounters vacuum boundary at surface {}", id_, surface_intersection_.second);
+    alive_ = false;
+  } else {
+    volume_ = xdg_->mesh_manager()->next_volume(volume_, surface_intersection_.second);
+    log("Particle {} enters volume {}", id_, volume_);
+    if (volume_ == ID_NONE) {
+      alive_ = false;
+      return;
+    }
+  }
+}
+
+// Data Members
+bool verbose_ {true};
+std::shared_ptr<XDG> xdg_;
+uint32_t id_ {0};
+int32_t max_events_ {1000};
+
+Position r_;
+Direction u_;
+MeshID volume_ {ID_NONE};
+std::vector<MeshID> history_ {};
+std::pair<double, MeshID> surface_intersection_ {INFTY, ID_NONE};
+double collision_distance_ {INFTY};
+int32_t n_events_ {0};
+bool alive_ {true};
+};
+
+void transport_particles(SimulationData& sim_data) {
+  // Problem Setup
+  srand48(42);
+  for (uint32_t i = 0; i < sim_data.n_particles_; i++) {
+    Particle p {sim_data.xdg_, i, sim_data.max_events_, sim_data.verbose_particles_};
+    p.initialize();
+    while (p.alive_) {
+      p.surf_dist();
+      p.sample_collision_distance(sim_data.mfp_);
+      p.advance(sim_data.cell_tracks);
+      if (p.collision_distance_ < p.surface_intersection_.first) {
+        p.collide();
+      } else {
+        p.cross_surface();
+      }
+    }
+  }
+}

--- a/tests/test_bvh.cpp
+++ b/tests/test_bvh.cpp
@@ -17,7 +17,7 @@ TEST_CASE("Test Mesh BVH")
 
   REQUIRE(mm->num_volumes() == 1);
   REQUIRE(mm->num_surfaces() == 6);
-  REQUIRE(mm->num_volume_elements(1) == 12);
+  REQUIRE(mm->num_volume_faces(1) == 12);
 
   std::shared_ptr<RayTracer> rti = std::make_shared<RayTracer>();
 

--- a/tests/test_libmesh.cpp
+++ b/tests/test_libmesh.cpp
@@ -222,6 +222,21 @@ TEST_CASE("Test Ray Fire Jezebel")
   }
 }
 
+TEST_CASE("Test Volume Element Count Jezebel")
+{
+  std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::LIBMESH);
+  xdg->mesh_manager()->mesh_library();
+  REQUIRE(xdg->mesh_manager()->mesh_library() == MeshLibrary::LIBMESH);
+  const auto& mesh_manager = xdg->mesh_manager();
+  mesh_manager->load_file("jezebel.exo");
+  mesh_manager->init();
+  xdg->prepare_raytracer();
+
+  MeshID volume = 1;
+
+  auto elements = mesh_manager->get_volume_elements(volume);
+  REQUIRE(elements.size() == 10333);
+}
 TEST_CASE("Test Point Location Jezebel")
 {
   std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::LIBMESH);
@@ -278,4 +293,23 @@ TEST_CASE("Test Point Location Cylinder-Brick")
   origin = {0.0, 0.0, 100.0};
   volume_id = xdg->find_volume(origin, direction);
   REQUIRE(volume_id == xdg->mesh_manager()->implicit_complement());
+}
+
+TEST_CASE("Test Volume Element Count Cylinder-Brick")
+{
+  std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::LIBMESH);
+  xdg->mesh_manager()->mesh_library();
+  REQUIRE(xdg->mesh_manager()->mesh_library() == MeshLibrary::LIBMESH);
+  const auto& mesh_manager = xdg->mesh_manager();
+  mesh_manager->load_file("cyl-brick.exo");
+  mesh_manager->init();
+  xdg->prepare_raytracer();
+
+  MeshID volume = 1;
+  auto elements = mesh_manager->get_volume_elements(volume);
+  REQUIRE(elements.size() == 7587);
+
+  volume = 2;
+  elements = mesh_manager->get_volume_elements(volume);
+  REQUIRE(elements.size() == 9037);
 }

--- a/tests/test_mesh_internal.cpp
+++ b/tests/test_mesh_internal.cpp
@@ -17,6 +17,6 @@ TEST_CASE("Test Mesh Mock")
 
   REQUIRE(mm->num_volumes() == 1);
   REQUIRE(mm->num_surfaces() == 6);
-  REQUIRE(mm->num_volume_elements(1) == 12);
+  REQUIRE(mm->num_volume_faces(1) == 12);
 }
 

--- a/tests/test_moab.cpp
+++ b/tests/test_moab.cpp
@@ -50,6 +50,11 @@ TEST_CASE("Test MOAB Initialization")
     auto prop = mesh_manager->get_surface_property(surface, PropertyType::BOUNDARY_CONDITION);
     REQUIRE(prop.value == "reflecting");
   }
+
+  // none of the volumes in this model should contain volumetric elements
+  for (auto volume : mesh_manager->volumes()) {
+    REQUIRE(mesh_manager->num_volume_elements(volume) == 0);
+  }
 }
 
 TEST_CASE("Test BVH Build")

--- a/tests/test_normal.cpp
+++ b/tests/test_normal.cpp
@@ -34,12 +34,12 @@ TEST_CASE("Test Get Normal")
 
   // call for the normal w/o a triangle, it should be the same as the returned triangle from the closest call
   Direction normal = xdg->surface_normal(surface, origin);
-  REQUIRE(normal == mm->triangle_normal(triangle));
+  REQUIRE(normal == mm->face_normal(triangle));
 
   // move the origin, but pass the triangle
   // This should result in the same normal as well b/c the triangle is used intead of a call to 'closest'
   origin = {-2.0, 0.0, 0.0};
   std::vector<MeshID> exclude_primitives {triangle};
   normal = xdg->surface_normal(surface, origin, &exclude_primitives);
-  REQUIRE(normal == mm->triangle_normal(triangle));
+  REQUIRE(normal == mm->face_normal(triangle));
 }


### PR DESCRIPTION
This PR switches some of the method naming so that methods with `*_faces` refer to 2D elements and `*_elements` refers to volumetric, 3D elements.

This is primarily to disambiguate the methods that collect all of the volume triangles from methods that I'll introduce to collect all of the volumetric elements when particles are walking element-to-element. 
