### PR TITLE
Adding a UML diagram to the documentation

### DIFF
--- a/docs/methods/design_philosophy.rst
+++ b/docs/methods/design_philosophy.rst
@@ -7,7 +7,8 @@ A UML diagram of the current XDG class hierarchy is shown below:
 
 .. raw:: html
 
-    <iframe width="800" height="600" src="https://drive.google.com/file/d/1jOOYsrMjI29D81mtemU_79hzjtlid_aa/preview"></iframe>
+    <iframe src="https://viewer.diagrams.net/?tags=%7B%7D&lightbox=1&highlight=000000&edit=_blank&layers=1&nav=1&title=xdg-uml.drawio&dark=0#Uhttps%3A%2F%2Fdrive.google.com%2Fuc%3Fid%3D1jOOYsrMjI29D81mtemU_79hzjtlid_aa%26export%3Ddownload"
+            width="800" height="600" frameborder="0"></iframe>
 
 The primary design goals of XDG are centered on the following:
 

--- a/docs/methods/design_philosophy.rst
+++ b/docs/methods/design_philosophy.rst
@@ -3,25 +3,31 @@
 XDG Design Philosophy
 =====================
 
+A UML diagram of the current XDG class hierarchy is shown below: 
+
+.. raw:: html
+
+    <iframe width="800" height="600" src="https://drive.google.com/file/d/1jOOYsrMjI29D81mtemU_79hzjtlid_aa/preview"></iframe>
+
 The primary design goals of XDG are centered on the following:
 
-    - **Mesh Library Abstraction**: all mesh-based operations in XDG are
-      abstracted through a common interface, the ``MeshManagerInterface``. This
-      allows for the use of multiple mesh libraries without changing the core
-      XDG codebase. A minimal implementation of the interface can be found in
-      the ``mesh_mock.h`` file in the test suite and is only ~100 lines long.
+- **Mesh Library Abstraction**: all mesh-based operations in XDG are
+  abstracted through a common interface, the ``MeshManagerInterface``. This
+  allows for the use of multiple mesh libraries without changing the core
+  XDG codebase. A minimal implementation of the interface can be found in
+  the ``mesh_mock.h`` file in the test suite and is only ~100 lines long.
 
-    - **Separation of Mesh and RayTracing Implementations**: XDG is designed to
-      separate the concerns of mesh interfaces and ray tracing. Mesh libraries
-      often implement their own acceleration data structures and ray tracing
-      algorithms. XDG is designed to build on top of these libraries and provide
-      a common interface for ray tracing operations that works for all of the
-      supported mesh libraries (see :ref:`xdg_intro`). This makes the library
-      agile and able to leverage the strengths of multiple mesh libraries along
-      with modern ray tracing algorithms.
+- **Separation of Mesh and RayTracing Implementations**: XDG is designed to
+  separate the concerns of mesh interfaces and ray tracing. Mesh libraries
+  often implement their own acceleration data structures and ray tracing
+  algorithms. XDG is designed to build on top of these libraries and provide
+  a common interface for ray tracing operations that works for all of the
+  supported mesh libraries (see :ref:`xdg_intro`). This makes the library
+  agile and able to leverage the strengths of multiple mesh libraries along
+  with modern ray tracing algorithms.
 
-    - **Ray Tracing Interface Abstraction**: all ray tracing operations in XDG are
-      abstracted through a common interface, the ``RayTracingInterface``. This
-      allows for the use of multiple ray tracing libraries without changing the
-      core XDG codebase. This is important for one of XDG's primary goals: to
-      support ray tracing on both CPUs and GPUs in a single binary.
+- **Ray Tracing Interface Abstraction**: all ray tracing operations in XDG are
+  abstracted through a common interface, the ``RayTracingInterface``. This
+  allows for the use of multiple ray tracing libraries without changing the
+  core XDG codebase. This is important for one of XDG's primary goals: to
+  support ray tracing on both CPUs and GPUs in a single binary.


### PR DESCRIPTION
This PR adds an embedded link to a UML diagram I am working on for XDG. Right now there is no extra styling and is literally just the html produced by draw.io to link to the draw.io diagram saved in my google drive, embedded directly in the documentation. 

The current plan is for this diagram to live in the design philosophy section of the documentation but I am happy for it to move if it makes sense to go somewhere else. 
