### PR TITLE
Expose methods to return MOAB vertices and connectivity

### DIFF
--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -99,6 +99,16 @@ public:
 
   std::vector<MeshID> get_volume_surfaces(MeshID volume) const override;
 
+  std::vector<int> get_surface_connectivity(MeshID surface) const override
+  {
+    fatal_error("LibMeshManager::get_surface_connectivity() not implemented yet");
+  }
+
+  std::vector<double> get_surface_vertices(MeshID surface) const override
+  {
+    fatal_error("LibMeshManager::get_surface_vertices() not implemented yet");
+  }
+
   MeshID create_volume() override;
 
   void add_surface_to_volume(MeshID volume, MeshID surface, Sense sense, bool overwrite=false) override;

--- a/include/xdg/mesh_manager_interface.h
+++ b/include/xdg/mesh_manager_interface.h
@@ -46,6 +46,11 @@ public:
 
   virtual std::array<Vertex, 3> face_vertices(MeshID element) const = 0;
 
+  virtual std::vector<int> get_surface_connectivity(MeshID surface) const = 0;
+
+  virtual std::vector<double> get_surface_vertices(MeshID surface) const = 0;
+
+
   BoundingBox element_bounding_box(MeshID element) const;
 
   BoundingBox face_bounding_box(MeshID element) const;

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -64,6 +64,10 @@ public:
 
   std::array<Vertex, 3> face_vertices(MeshID element) const override;
 
+  std::vector<int> get_surface_connectivity(MeshID surface) const;
+
+  std::vector<double> get_surface_vertices(MeshID surface) const;
+
   // Topology
   std::pair<MeshID, MeshID> surface_senses(MeshID surface) const override;
 

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -64,9 +64,9 @@ public:
 
   std::array<Vertex, 3> face_vertices(MeshID element) const override;
 
-  std::vector<int> get_surface_connectivity(MeshID surface) const;
+  std::vector<int> get_surface_connectivity(MeshID surface) const override;
 
-  std::vector<double> get_surface_vertices(MeshID surface) const;
+  std::vector<double> get_surface_vertices(MeshID surface) const override;
 
   // Topology
   std::pair<MeshID, MeshID> surface_senses(MeshID surface) const override;

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -269,6 +269,35 @@ MOABMeshManager::get_volume_surfaces(MeshID volume) const
   return surface_ids;
 }
 
+std::vector<int> 
+MOABMeshManager::get_surface_connectivity(MeshID surface) const
+{
+  moab::EntityHandle surf_handle = this->surface_id_map_.at(surface);
+  auto faces = _surface_faces(surface);
+
+  moab::Range conn;
+  this->moab_interface()->get_connectivity(faces, conn);
+
+  std::vector<int> connectivity;
+  connectivity.insert(connectivity.end(), conn.begin(), conn.end());
+
+  return connectivity;
+}
+
+std::vector<double> 
+MOABMeshManager::get_surface_vertices(MeshID surface) const
+{
+  auto conn = get_surface_connectivity(surface);
+  std::vector<moab::EntityHandle> verts;
+
+  verts.insert(verts.end(), conn.begin(), conn.end());
+  std::vector<double> coords(verts.size() * 3);
+
+  this->moab_interface()->get_coords(verts.data(), verts.size(), coords.data());
+
+  return coords;
+}
+
 void
 MOABMeshManager::parse_metadata()
 {

--- a/tests/mesh_mock.h
+++ b/tests/mesh_mock.h
@@ -75,6 +75,32 @@ public:
     return {vertices[0], vertices[1], vertices[2]};
   }
 
+  std::vector<int> get_surface_connectivity(MeshID surface) const override
+  {
+    std::vector<int> flat_connectivity;
+    flat_connectivity.reserve(triangle_connectivity.size() * 3);
+    
+    for (const auto& tri : triangle_connectivity) {
+      flat_connectivity.insert(flat_connectivity.end(), tri.begin(), tri.end());
+    }
+
+    return flat_connectivity;
+  }
+
+  std::vector<double> get_surface_vertices(MeshID surface) const override
+  {
+    std::vector<double> flat_vertices;
+    flat_vertices.reserve(vertices.size() * 3);
+    
+    for (const auto& vertex : vertices) {
+      flat_vertices.push_back(vertex.x);
+      flat_vertices.push_back(vertex.y);
+      flat_vertices.push_back(vertex.z);
+    }
+
+    return flat_vertices;
+  }
+
   // Topology
   virtual std::pair<MeshID, MeshID> surface_senses(MeshID surface) const override {
     return {0, ID_NONE};

--- a/tests/test_moab.cpp
+++ b/tests/test_moab.cpp
@@ -111,6 +111,36 @@ TEST_CASE("Test Ray Fire MOAB")
 
 }
 
+TEST_CASE("MOAB Vertices")
+{
+  std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
+  REQUIRE(xdg->mesh_manager()->mesh_library() == MeshLibrary::MOAB);
+  const auto& mesh_manager = xdg->mesh_manager();
+  mesh_manager->load_file("cube.h5m");
+  mesh_manager->init();
+
+  int vertex_count = 0;
+
+  for (const auto surface: mesh_manager->surfaces()) {
+    auto vertices = mesh_manager->get_surface_vertices(surface);
+    REQUIRE(vertices.size() / 3 == 138); // Each surface should contain exactly 138 nodes
+  }
+}
+
+TEST_CASE("MOAB Connectivity")
+{
+  std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
+  REQUIRE(xdg->mesh_manager()->mesh_library() == MeshLibrary::MOAB);
+  const auto& mesh_manager = xdg->mesh_manager();
+  mesh_manager->load_file("cube.h5m");
+  mesh_manager->init();
+
+  for (const auto surface: mesh_manager->surfaces()) {
+    auto connectivity = mesh_manager->get_surface_connectivity(surface);
+    REQUIRE(connectivity.size() == 138); // Each surface should contain exactly 138 nodes
+  }
+}
+
 TEST_CASE("TEST XDG Factory Method")
 {
 


### PR DESCRIPTION
This PR adds methods to the mesh manager interface to return the coordinates of vertices in a MOAB mesh as well as the connectivity between those vertices. The motivation for publicly exposing this is to make it easier to use the `MeshManager` API to transfer element vertices/indices to a GPRT buffer for building acceleration structures on device. 

Two methods have been added:
- `MeshManager::get_surface_vertices(MeshID surface)` returns a flattened std::vector<double> of xyz coords of all the vertices in a surface.
- `MeshManager::get_surface_connectivity(MeshID surface)` returns a flattened std::vector<int> of indices for each vertex in a surface.

I've also added a couple tests to `test_moab.cpp` to ensure that these methods are returning the correct the number of vertices/indices. And added stubs for the `LibMeshManager`.

@pshriwise please let me know if you feel like this shouldn't be exposed in the `MeshManager` or if it makes more sense for the methods to return non-flattened vectors, etc...