### PR TITLE
Added [[Noreturn]] attribute on XDG fatal errors

### DIFF
--- a/include/xdg/error.h
+++ b/include/xdg/error.h
@@ -16,7 +16,7 @@ void write_message(const std::string& message, const Params&... fmt_args)
   write_message(fmt::format(message, fmt_args...));
 }
 
-void fatal_error(const std::string& message, int err=-1);
+[[noreturn]] void fatal_error(const std::string& message, int err=-1);
 
 template<typename... Params>
 void fatal_error(const std::string& message, const Params&... fmt_args)

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -38,7 +38,7 @@ void write_message(const std::string& message)
     output(message, std::cout, 1);
 }
 
-void fatal_error(const std::string& message, int err)
+[[noreturn]] void fatal_error(const std::string& message, int err)
 {
 #ifdef _POSIX_VERSION
   // Make output red if user is in a terminal


### PR DESCRIPTION
Super minor PR that adds the [[noreturn]] attribute to the `fatal_error()` function defined in `error.h`. 

Since `fatal_error()` always results in exiting the application the control logic will never return to the caller - `[[noreturn]]` explicitly specifies this to the compiler, which should suppress the compiler warning: `warning: no return statement in function returning non-void [-Wreturn-type]`. 