### PR TITLE
Embree tetrahedral search callbacks

### DIFF
--- a/docs/methods/element_search.rst
+++ b/docs/methods/element_search.rst
@@ -1,0 +1,44 @@
+
+
+Element Search
+==============
+
+The underlying data structure for element search used by Embree is a Bouding
+Volume Hierarchy (BVH), which is a tree of bounding boxes that is used to
+quickly determine if a ray intersects a primitive. This data structure is
+typically used to accelerate ray queries for the nearest intersection against
+sets of 2D primitives.
+
+This data structure can also be used to accelerate queries for the containment
+of a point within a set of 3D primitives (elements in the parlance of XDG).
+
+To perform an element search, we first need to build the BVH. This is done by
+providing Embree with a a custom user geometry for the 3D elements with the
+ability to call back into the relevant `MeshManager` to get the bounding box of
+the each element. Because Embree operates in single precision, the bounding boxes
+of elements are dilated conservatively and provided to embree in single precision.
+
+When a point containment query is performed, a ray is constructed from the point
+and a length of zero, resulting in positive ray-box intersections only if the
+point resides within the bounding box of the element. At the botton of the
+hierarchy, the elements are identified and the primitive reference is returned.
+Thus far computation occurs in single precision.
+
+A double-precision evaluation is performed to determine if the point resides within
+the element. This is done by computing the barycentric coordinates of the point
+with respect to the element. If the point resides within the element, the primitive
+reference is returned.
+
+Because the point containment query departs from a the types of ray queries
+performed in the common surface ray tracing required by particle transport (in
+which one is interested in the nearest intersection along the particle's
+trajectory), we here use a call to Embree's `rtcOccluded` function as it will
+return the first positive containment result for the query. Given that a point
+should not be contained by more than one element, this call is sufficient and
+will result in fewer element containment checks in double-precision.
+
+
+
+
+
+

--- a/docs/methods/index.rst
+++ b/docs/methods/index.rst
@@ -9,3 +9,4 @@ Methods
     design_philosophy
     acceleration_data_structures
     primitive_intersection
+    element_search

--- a/docs/methods/primitive_intersection.rst
+++ b/docs/methods/primitive_intersection.rst
@@ -7,7 +7,6 @@ Primitive Intersections
 Currently XDG supports ray intersections with the following primitives:
 
    - linear triangles
-   - linear quads
 
 Triangle intersection tests are performed using the Pluecker triangle
 intersection test. This method uses Pluecker coordinates (formed from the
@@ -15,8 +14,6 @@ cross-product of the ray direction and triangle edges) to determine if a ray
 intersects a triangle. It is known for its numerical stability and efficiency,
 making it suitable for scientific ray tracing applications [1]_.
 
-Quad intersection tests are performed by splitting the quad into two triangles
-and performing the Pluecker triangle intersection test on each triangle.
 
 Assumptions about the normals of primitives are based the cannonical ordering
 established by this paper [2]_.

--- a/include/xdg/geometry_data.h
+++ b/include/xdg/geometry_data.h
@@ -16,5 +16,11 @@ struct GeometryUserData {
   double box_bump; //! Bump distance for the bounding boxes in this geometry
 };
 
+struct VolumeElementsUserData {
+  MeshID volume_id {ID_NONE}; //! ID of the volume this geometry data is associated with
+  MeshManager* mesh_manager {nullptr}; //! Pointer to the mesh manager for this geometry
+  PrimitiveRef* prim_ref_buffer {nullptr}; //! Pointer to the mesh primitives in the geometry
+};
+
 } // namespace xdg
 #endif // include guard

--- a/include/xdg/ray.h
+++ b/include/xdg/ray.h
@@ -89,8 +89,8 @@ struct RTCSurfaceDualRay : RTCDualRay {
   const std::vector<MeshID>* exclude_primitives {nullptr}; //! < Set of primitives to exclude from the query
 };
 
-struct RTCElementRay : RTCDualRay {
-  RTCElementRay() {
+struct RTCElementDualRay : RTCDualRay {
+  RTCElementDualRay() {
     this->element = ID_NONE;
   }
 

--- a/include/xdg/ray.h
+++ b/include/xdg/ray.h
@@ -21,9 +21,9 @@ class TriangleRef;
     double precision versions of the origin, direction
     and intersection distance.
  */
-struct RTCDRay: RTCRay {
+struct RTCDualRay : RTCRay {
 
-  RTCDRay() {
+  RTCDualRay() {
     this->tnear = 0.0;
     this->tfar = INFTYF;
     this->mask = -1;
@@ -76,12 +76,29 @@ struct RTCDRay: RTCRay {
     tnear = d;
   }
 
-  // Member variables
-  RayFireType rf_type; //!< Enum indicating the type of query this ray is used for
   Vec3da dorg, ddir; //!< double precision versions of the origin and ray direction
   double dtfar; //!< double precision version of the ray far distance
+};
+
+
+struct RTCSurfaceRay : RTCDualRay {
+
+  // Member variables
+  RayFireType rf_type; //!< Enum indicating the type of query this ray is used for
   HitOrientation orientation; //!< Enum indicating what hits to accept based on orientation
   const std::vector<MeshID>* exclude_primitives {nullptr}; //! < Set of primitives to exclude from the query
+};
+
+// temporary alias for the dual ray
+using RTCDRay = RTCSurfaceRay;
+
+struct RTCElementRay : RTCDualRay {
+  RTCElementRay() {
+    this->element = ID_NONE;
+  }
+
+  // Member variables
+  MeshID element; //!< ID of the element this ray is associated with
 };
 
 /*! Structure extending Embree's RayHit to include a double precision version of the primitive normal */
@@ -102,7 +119,7 @@ struct RTCDHit : RTCHit {
 
 /*! Stucture combining the ray and ray-hit structures to be passed to Embree queries */
 struct RTCDRayHit {
-  struct RTCDRay ray; //<! Extended version of the Embree RTCRay struct with double precision values
+  struct RTCSurfaceRay ray; //<! Extended version of the Embree RTCRay struct with double precision values
   struct RTCDHit hit; //<! Extended version of the Embree RTDRayHit struct with double precision values
 
   //! \brief Compute the dot product of the ray direction and current hit normal
@@ -145,6 +162,5 @@ struct RTCDPointQuery : RTCPointQuery {
 };
 
 } // namespace xdg
-
 
 #endif // include guard

--- a/include/xdg/ray.h
+++ b/include/xdg/ray.h
@@ -81,7 +81,7 @@ struct RTCDualRay : RTCRay {
 };
 
 
-struct RTCSurfaceRay : RTCDualRay {
+struct RTCSurfaceDualRay : RTCDualRay {
 
   // Member variables
   RayFireType rf_type; //!< Enum indicating the type of query this ray is used for
@@ -116,7 +116,7 @@ struct RTCDualHit : RTCHit {
 
 /*! Stucture combining the ray and ray-hit structures to be passed to Embree queries */
 struct RTCDualRayHit {
-  struct RTCSurfaceRay ray; //<! Extended version of the Embree RTCRay struct with double precision values
+  struct RTCSurfaceDualRay ray; //<! Extended version of the Embree RTCRay struct with double precision values
   struct RTCDualHit hit; //<! Extended version of the Embree RTDRayHit struct with double precision values
 
   //! \brief Compute the dot product of the ray direction and current hit normal

--- a/include/xdg/ray.h
+++ b/include/xdg/ray.h
@@ -89,9 +89,6 @@ struct RTCSurfaceRay : RTCDualRay {
   const std::vector<MeshID>* exclude_primitives {nullptr}; //! < Set of primitives to exclude from the query
 };
 
-// temporary alias for the dual ray
-using RTCDRay = RTCSurfaceRay;
-
 struct RTCElementRay : RTCDualRay {
   RTCElementRay() {
     this->element = ID_NONE;
@@ -102,8 +99,8 @@ struct RTCElementRay : RTCDualRay {
 };
 
 /*! Structure extending Embree's RayHit to include a double precision version of the primitive normal */
-struct RTCDHit : RTCHit {
-  RTCDHit() {
+struct RTCDualHit : RTCHit {
+  RTCDualHit() {
     this->geomID = RTC_INVALID_GEOMETRY_ID;
     this->primID = RTC_INVALID_GEOMETRY_ID;
     this->Ng_x = 0.0;
@@ -118,9 +115,9 @@ struct RTCDHit : RTCHit {
 };
 
 /*! Stucture combining the ray and ray-hit structures to be passed to Embree queries */
-struct RTCDRayHit {
+struct RTCDualRayHit {
   struct RTCSurfaceRay ray; //<! Extended version of the Embree RTCRay struct with double precision values
-  struct RTCDHit hit; //<! Extended version of the Embree RTDRayHit struct with double precision values
+  struct RTCDualHit hit; //<! Extended version of the Embree RTDRayHit struct with double precision values
 
   //! \brief Compute the dot product of the ray direction and current hit normal
   double dot_prod() {

--- a/include/xdg/tetrahedron_contain.h
+++ b/include/xdg/tetrahedron_contain.h
@@ -37,6 +37,11 @@ bool plucker_tet_containment_test(const Position& point,
                                   const Vertex& v2,
                                   const Vertex& v3);
 
+// Embree call back functions for element search
+void VolumeElementBoundsFunc(RTCBoundsFunctionArguments* args);
+void TetrahedronIntersectionFunc(RTCIntersectFunctionNArguments* args);
+void TetrahedronOcclusionFunc(RTCOccludedFunctionNArguments* args);
+
 } // namespace xdg
 
 #endif // include guard

--- a/include/xdg/tetrahedron_contain.h
+++ b/include/xdg/tetrahedron_contain.h
@@ -6,7 +6,6 @@
 
 namespace xdg
 {
-
 /**
  * @brief Determines if a point is inside or on the boundary of a tetrahedron
  * using Plücker coordinates.

--- a/src/embree/ray_tracer.cpp
+++ b/src/embree/ray_tracer.cpp
@@ -217,7 +217,7 @@ bool EmbreeRayTracer::occluded(TreeID tree,
                          double& distance) const
 {
   RTCScene scene = tree_to_scene_map_.at(tree);
-  RTCSurfaceRay ray;
+  RTCSurfaceDualRay ray;
   ray.set_org(origin);
   ray.set_dir(direction);
   ray.set_tfar(INFTY);

--- a/src/embree/ray_tracer.cpp
+++ b/src/embree/ray_tracer.cpp
@@ -121,7 +121,7 @@ bool EmbreeRayTracer::point_in_volume(TreeID tree,
                                 const std::vector<MeshID>* exclude_primitives) const
 {
   RTCScene scene = tree_to_scene_map_.at(tree);
-  RTCDRayHit rayhit; // embree specfic rayhit struct (payload?)
+  RTCDualRayHit rayhit; // embree specfic rayhit struct (payload?)
   rayhit.ray.set_org(point);
   if (direction != nullptr) rayhit.ray.set_dir(*direction);
   else rayhit.ray.set_dir({1. / std::sqrt(2.0), 1 / std::sqrt(2.0), 0.0});
@@ -153,7 +153,7 @@ EmbreeRayTracer::ray_fire(TreeID tree,
                     std::vector<MeshID>* const exclude_primitves)
 {
   RTCScene scene = tree_to_scene_map_.at(tree);
-  RTCDRayHit rayhit;
+  RTCDualRayHit rayhit;
   // set ray data
   rayhit.ray.set_org(origin);
   rayhit.ray.set_dir(direction);
@@ -217,7 +217,7 @@ bool EmbreeRayTracer::occluded(TreeID tree,
                          double& distance) const
 {
   RTCScene scene = tree_to_scene_map_.at(tree);
-  RTCDRay ray;
+  RTCSurfaceRay ray;
   ray.set_org(origin);
   ray.set_dir(direction);
   ray.set_tfar(INFTY);

--- a/src/tetrahedron_contain.cpp
+++ b/src/tetrahedron_contain.cpp
@@ -52,14 +52,7 @@ void VolumeElementBoundsFunc(RTCBoundsFunctionArguments* args)
   const PrimitiveRef& primitive_ref = user_data->prim_ref_buffer[args->primID];
 
   BoundingBox bounds = mesh_manager->element_bounding_box(primitive_ref.primitive_id);
-
-  // the bump value can be localized to this element
-  // TODO: replace with bounds.maximum_chord_length()
-  double dx = bounds.max_x - bounds.min_x;
-  double dy = bounds.max_y - bounds.min_y;
-  double dz = bounds.max_z - bounds.min_z;
-  double max_distance = std::sqrt(dx*dx + dy*dy + dz*dz);
-  double bump = max_distance * std::pow(10, -std::numeric_limits<float>::digits10);
+  double bump = bounds.dilation();
 
   args->bounds_o->lower_x = bounds.min_x - bump;
   args->bounds_o->lower_y = bounds.min_y - bump;

--- a/src/tetrahedron_contain.cpp
+++ b/src/tetrahedron_contain.cpp
@@ -71,7 +71,7 @@ void TetrahedronIntersectionFunc(RTCIntersectFunctionNArguments* args) {
   auto vertices = mesh_manager->element_vertices(primitive_ref.primitive_id);
 
   RTCDualRayHit* rayhit = (RTCDualRayHit*)args->rayhit;
-  RTCSurfaceRay& ray = rayhit->ray;
+  RTCSurfaceDualRay& ray = rayhit->ray;
   RTCDualHit& hit = rayhit->hit;
 
   Position ray_origin = {ray.dorg[0], ray.dorg[1], ray.dorg[2]};

--- a/src/tetrahedron_contain.cpp
+++ b/src/tetrahedron_contain.cpp
@@ -42,4 +42,82 @@ bool plucker_tet_containment_test(const Position& point,
     return true;
 }
 
+// Embree callbacks
+
+void VolumeElementBoundsFunc(RTCBoundsFunctionArguments* args)
+{
+  const VolumeElementsUserData* user_data = (const VolumeElementsUserData*)args->geometryUserPtr;
+  const MeshManager* mesh_manager = user_data->mesh_manager;
+
+  const PrimitiveRef& primitive_ref = user_data->prim_ref_buffer[args->primID];
+
+  BoundingBox bounds = mesh_manager->element_bounding_box(primitive_ref.primitive_id);
+
+  // the bump value can be localized to this element
+  // TODO: replace with bounds.maximum_chord_length()
+  double dx = bounds.max_x - bounds.min_x;
+  double dy = bounds.max_y - bounds.min_y;
+  double dz = bounds.max_z - bounds.min_z;
+  double max_distance = std::sqrt(dx*dx + dy*dy + dz*dz);
+  double bump = max_distance * std::pow(10, -std::numeric_limits<float>::digits10);
+
+  args->bounds_o->lower_x = bounds.min_x - bump;
+  args->bounds_o->lower_y = bounds.min_y - bump;
+  args->bounds_o->lower_z = bounds.min_z - bump;
+  args->bounds_o->upper_x = bounds.max_x + bump;
+  args->bounds_o->upper_y = bounds.max_y + bump;
+  args->bounds_o->upper_z = bounds.max_z + bump;
+}
+
+void TetrahedronIntersectionFunc(RTCIntersectFunctionNArguments* args) {
+  const VolumeElementsUserData* user_data = (const VolumeElementsUserData*)args->geometryUserPtr;
+  const MeshManager* mesh_manager = user_data->mesh_manager;
+
+  // TODO: Update this!
+  const PrimitiveRef primitive_ref = user_data->prim_ref_buffer[args->primID];
+  auto vertices = mesh_manager->element_vertices(primitive_ref.primitive_id);
+
+  RTCDRayHit* rayhit = (RTCDRayHit*)args->rayhit;
+  RTCSurfaceRay& ray = rayhit->ray;
+  RTCDHit& hit = rayhit->hit;
+
+  Position ray_origin = {ray.dorg[0], ray.dorg[1], ray.dorg[2]};
+
+  // check the containment of the point
+  bool inside = plucker_tet_containment_test(ray_origin, vertices[0], vertices[1], vertices[2], vertices[3]);
+
+  if (!inside) return;
+  // zero out the hit information
+  rayhit->hit.u = 0.0;
+  rayhit->hit.v = 0.0;
+  rayhit->hit.Ng_x = 0.0;
+  rayhit->hit.Ng_y = 0.0;
+  rayhit->hit.Ng_z = 0.0;
+  // set the hit information
+  rayhit->hit.geomID = args->geomID;
+  rayhit->hit.primID = args->primID;
+}
+
+void TetrahedronOcclusionFunc(RTCOccludedFunctionNArguments* args)
+{
+  const VolumeElementsUserData* user_data = (const VolumeElementsUserData*)args->geometryUserPtr;
+  const MeshManager* mesh_manager = user_data->mesh_manager;
+
+  const PrimitiveRef primitive_ref = user_data->prim_ref_buffer[args->primID];
+
+  auto vertices = mesh_manager->element_vertices(primitive_ref.primitive_id);
+
+  RTCElementRay* ray = (RTCElementRay*)args->ray;
+  Position ray_origin = {ray->dorg[0], ray->dorg[1], ray->dorg[2]};
+
+  // check the containment of the point
+  bool inside = plucker_tet_containment_test(ray_origin, vertices[0], vertices[1], vertices[2], vertices[3]);
+
+  if (!inside) return;
+
+  // set the hit information
+  ray->element = primitive_ref.primitive_id;
+  ray->set_tfar(-INFTY);
+}
+
 } // namespace xdg

--- a/src/tetrahedron_contain.cpp
+++ b/src/tetrahedron_contain.cpp
@@ -100,7 +100,7 @@ void TetrahedronOcclusionFunc(RTCOccludedFunctionNArguments* args)
 
   auto vertices = mesh_manager->element_vertices(primitive_ref.primitive_id);
 
-  RTCElementRay* ray = (RTCElementRay*)args->ray;
+  RTCElementDualRay* ray = (RTCElementDualRay*)args->ray;
   Position ray_origin = {ray->dorg[0], ray->dorg[1], ray->dorg[2]};
 
   // check the containment of the point

--- a/src/tetrahedron_contain.cpp
+++ b/src/tetrahedron_contain.cpp
@@ -77,9 +77,9 @@ void TetrahedronIntersectionFunc(RTCIntersectFunctionNArguments* args) {
   const PrimitiveRef primitive_ref = user_data->prim_ref_buffer[args->primID];
   auto vertices = mesh_manager->element_vertices(primitive_ref.primitive_id);
 
-  RTCDRayHit* rayhit = (RTCDRayHit*)args->rayhit;
+  RTCDualRayHit* rayhit = (RTCDualRayHit*)args->rayhit;
   RTCSurfaceRay& ray = rayhit->ray;
-  RTCDHit& hit = rayhit->hit;
+  RTCDualHit& hit = rayhit->hit;
 
   Position ray_origin = {ray.dorg[0], ray.dorg[1], ray.dorg[2]};
 

--- a/src/triangle_intersect.cpp
+++ b/src/triangle_intersect.cpp
@@ -23,12 +23,11 @@ bool orientation_cull(const Direction& ray_dir, const Direction& normal, HitOrie
   return false;
 }
 
-bool primitive_mask_cull(RTCDRayHit* rayhit, int primID) {
+bool primitive_mask_cull(RTCDualRayHit* rayhit, int primID) {
   if (!rayhit->ray.exclude_primitives) return false;
 
-  RTCDRay& ray = rayhit->ray;
-  RTCDHit& hit = rayhit->hit;
-
+  RTCSurfaceRay& ray = rayhit->ray;
+  RTCDualHit& hit = rayhit->hit;
 
   // if the primitive mask is set, cull if the primitive is not in the mask
   return std::find(ray.exclude_primitives->begin(), ray.exclude_primitives->end(), primID) != ray.exclude_primitives->end();
@@ -58,9 +57,9 @@ void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
 
   auto vertices = mesh_manager->face_vertices(primitive_ref.primitive_id);
 
-  RTCDRayHit* rayhit = (RTCDRayHit*)args->rayhit;
-  RTCDRay& ray = rayhit->ray;
-  RTCDHit& hit = rayhit->hit;
+  RTCDualRayHit* rayhit = (RTCDualRayHit*)args->rayhit;
+  RTCSurfaceRay& ray = rayhit->ray;
+  RTCDualHit& hit = rayhit->hit;
 
   Position ray_origin = {ray.dorg[0], ray.dorg[1], ray.dorg[2]};
   Direction ray_direction = {ray.ddir[0], ray.ddir[1], ray.ddir[2]};
@@ -135,7 +134,7 @@ void TriangleOcclusionFunc(RTCOccludedFunctionNArguments* args) {
   auto vertices = mesh_manager->face_vertices(primitive_ref.primitive_id);
 
   // get the double precision ray from the args
-  RTCDRay* ray = (RTCDRay*) args->ray;
+  RTCSurfaceRay* ray = (RTCSurfaceRay*) args->ray;
 
   double plucker_dist;
   if (plucker_ray_tri_intersect(vertices, ray->dorg, ray->ddir, plucker_dist)) {

--- a/src/triangle_intersect.cpp
+++ b/src/triangle_intersect.cpp
@@ -26,7 +26,7 @@ bool orientation_cull(const Direction& ray_dir, const Direction& normal, HitOrie
 bool primitive_mask_cull(RTCDualRayHit* rayhit, int primID) {
   if (!rayhit->ray.exclude_primitives) return false;
 
-  RTCSurfaceRay& ray = rayhit->ray;
+  RTCSurfaceDualRay& ray = rayhit->ray;
   RTCDualHit& hit = rayhit->hit;
 
   // if the primitive mask is set, cull if the primitive is not in the mask
@@ -58,7 +58,7 @@ void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
   auto vertices = mesh_manager->face_vertices(primitive_ref.primitive_id);
 
   RTCDualRayHit* rayhit = (RTCDualRayHit*)args->rayhit;
-  RTCSurfaceRay& ray = rayhit->ray;
+  RTCSurfaceDualRay& ray = rayhit->ray;
   RTCDualHit& hit = rayhit->hit;
 
   Position ray_origin = {ray.dorg[0], ray.dorg[1], ray.dorg[2]};
@@ -134,7 +134,7 @@ void TriangleOcclusionFunc(RTCOccludedFunctionNArguments* args) {
   auto vertices = mesh_manager->face_vertices(primitive_ref.primitive_id);
 
   // get the double precision ray from the args
-  RTCSurfaceRay* ray = (RTCSurfaceRay*) args->ray;
+  RTCSurfaceDualRay* ray = (RTCSurfaceDualRay*) args->ray;
 
   double plucker_dist;
   if (plucker_ray_tri_intersect(vertices, ray->dorg, ray->ddir, plucker_dist)) {


### PR DESCRIPTION
This adds the set of callbacks needed for Embree to use the tetrahedron containment check function.

A new struct, `RTCElementRay` that supports discovery of a containing element with a zero-length array. Some high-level notes have been added to describe the process by which element searches will occur using these methods.

In isolation, these callbacks don't add any functionality to the library, but I feel it's a relatively coherent starting point before adding the code that includes the construction of and querying of Embree geometries and scenes.