### PR TITLE
Enabling find_element operations

### DIFF
--- a/include/xdg/constants.h
+++ b/include/xdg/constants.h
@@ -72,6 +72,8 @@ constexpr MeshID ID_NONE {-1};
 
 // Scene/Tree ID
 using TreeID = int32_t;
+using SurfaceTreeID = TreeID;
+using ElementTreeID = TreeID;
 
 // Null tree ID
 constexpr TreeID TREE_NONE {-1};

--- a/include/xdg/constants.h
+++ b/include/xdg/constants.h
@@ -67,14 +67,14 @@ static const std::map<RTLibrary, std::string> RT_LIB_TO_STR =
 // Mesh identifer type
 using MeshID = int32_t;
 
-// Invalid
+// Null mesh ID
 constexpr MeshID ID_NONE {-1};
 
 // Scene/Tree ID
 using TreeID = int32_t;
 
-// Invalid
-constexpr TreeID TREEID_NONE {-1};
+// Null tree ID
+constexpr TreeID TREE_NONE {-1};
 
 // for abs(x) >= min_rcp_input the newton raphson rcp calculation does not fail
 constexpr float min_rcp_input = std::numeric_limits<float>::min() /* FIX ME */ *1E5 /* SHOULDNT NEED TO MULTIPLY BY THIS VALUE */;

--- a/include/xdg/embree/ray_tracer.h
+++ b/include/xdg/embree/ray_tracer.h
@@ -66,10 +66,6 @@ public:
                 const Direction& direction,
                 double& dist) const override;
 
-  // Accessors
-  const std::shared_ptr<SurfaceUserData>& geometry_data(MeshID surface) const override
-  { return surface_user_data_map_.at(surface_to_geometry_map_.at(surface)); };
-
   // Embree members
   RTCDevice device_;
   std::vector<RTCGeometry> geometries_; //<! All geometries created by this ray tracer

--- a/include/xdg/embree/ray_tracer.h
+++ b/include/xdg/embree/ray_tracer.h
@@ -77,7 +77,8 @@ public:
   std::unordered_map<RTCGeometry, std::shared_ptr<SurfaceUserData>> surface_user_data_map_;
   std::unordered_map<RTCGeometry, std::shared_ptr<VolumeElementsUserData>> volume_user_data_map_;
 
-  std::unordered_map<TreeID, RTCScene> tree_to_scene_map_; // Map from XDG::TreeID to specific embree scene/tree
+  std::unordered_map<SurfaceTreeID, RTCScene> surface_volume_tree_to_scene_map_; // Map from SurfaceVolumeTreeID to specific embree scene/tree
+  std::unordered_map<ElementTreeID, RTCScene> element_volume_tree_to_scene_map_; // Map from ElementVolumeTreeID to specific embree scene/tree
 
   // storage
   std::unordered_map<RTCScene, std::vector<PrimitiveRef>> primitive_ref_storage_;
@@ -89,6 +90,7 @@ private:
                                                                              int& storage_offset);
   RTCScene global_surface_scene_ {nullptr};
   RTCScene global_element_scene_ {nullptr};
+
 };
 
 } // namespace xdg

--- a/include/xdg/error.h
+++ b/include/xdg/error.h
@@ -19,6 +19,12 @@ void write_message(const std::string& message, const Params&... fmt_args)
 [[noreturn]] void fatal_error(const std::string& message, int err=-1);
 
 template<typename... Params>
+void warning(const std::string& message, const Params&... fmt_args)
+{
+  write_message(fmt::format("Warning: {}", message, fmt_args...));
+}
+
+template<typename... Params>
 void fatal_error(const std::string& message, const Params&... fmt_args)
 {
     fatal_error(fmt::format(message, fmt_args...));

--- a/include/xdg/geometry_data.h
+++ b/include/xdg/geometry_data.h
@@ -9,7 +9,7 @@ namespace xdg
 struct MeshManager; // Forward declaration
 struct PrimitiveRef; // Forward declaration
 
-struct GeometryUserData {
+struct SurfaceUserData {
   MeshID surface_id {ID_NONE}; //! ID of the surface this geometry data is associated with
   MeshManager* mesh_manager {nullptr}; //! Pointer to the mesh manager for this geometry
   PrimitiveRef* prim_ref_buffer {nullptr}; //! Pointer to the mesh primitives in the geometry

--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -297,7 +297,8 @@ public:
   protected:
   // TODO: make this global so it isn't owned by a single mesh manager
   std::unique_ptr<libMesh::LibMeshInit> libmesh_init {nullptr};
-  // this attribute must come after libmesh_init so that it is destroyed last
+
+  // THIS MUST COME AFTER libmesh_init SO THAT IT IS DESTROYED LAST
   std::unique_ptr<libMesh::Mesh> mesh_ {nullptr};
 
   // Ugh, double mapping

--- a/include/xdg/mesh_manager_interface.h
+++ b/include/xdg/mesh_manager_interface.h
@@ -58,9 +58,11 @@ public:
 
   BoundingBox face_bounding_box(MeshID element) const;
 
+  BoundingBox surface_bounding_box(MeshID surface) const;
+
   BoundingBox volume_bounding_box(MeshID volume) const;
 
-  BoundingBox surface_bounding_box(MeshID surface) const;
+  BoundingBox global_bounding_box() const;
 
   Direction face_normal(MeshID element) const;
 

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -109,6 +109,9 @@ private:
   std::unordered_map<MeshID, moab::EntityHandle> volume_id_map_;
   std::unordered_map<MeshID, moab::EntityHandle> surface_id_map_;
 
+  // Maps elements to their volume ID
+  std::unordered_map<MeshID, MeshID> element_volume_ids_;
+
   // tag handles
   moab::Tag geometry_dimension_tag_;
   moab::Tag global_id_tag_;

--- a/include/xdg/ray_tracing_interface.h
+++ b/include/xdg/ray_tracing_interface.h
@@ -122,28 +122,31 @@ public:
                 double& dist) const = 0;
 
   // Generic Accessors
-  int num_registered_trees() const { return trees_.size(); };
+  int num_registered_trees() const { return surface_trees_.size() + element_trees_.size(); };
+  int num_registered_surface_trees() const { return surface_trees_.size(); };
+  int num_registered_element_trees() const { return element_trees_.size(); };
 
-  const std::vector<MeshID>& trees() const { return trees_; }
-
-// TODO: Think about which variables will be shared between RayTracers independent of which library is used
-// Right now I have moved pretty much everything into EmbreeRayTracer whilst this sits as an abstract interface
 protected:
   // Common functions across RayTracers
   const double bounding_box_bump(const std::shared_ptr<MeshManager> mesh_manager, MeshID volume_id); // return a bump value based on the size of a bounding box (minimum 1e-3). Should this be a part of mesh_manager?
 
-  TreeID next_tree_id() const; // get next treeid
+  SurfaceTreeID next_surface_tree_id(); // get next surface treeid
+  ElementTreeID next_element_tree_id(); // get next element treeid
 
   // Common member variables across RayTracers
 
-  TreeID global_surface_tree_ {TREE_NONE}; //<! TreeID for the global surface tree
-  TreeID global_element_tree_ {TREE_NONE}; //<! TreeID for the global element tree
+  SurfaceTreeID global_surface_tree_ {TREE_NONE}; //<! TreeID for the global surface tree
+  ElementTreeID global_element_tree_ {TREE_NONE}; //<! TreeID for the global element tree
 
-  std::map<MeshID, TreeID> surface_to_tree_map_; //<! Map from mesh surface to embree scene
-  std::map<MeshID, TreeID> point_location_tree_map_; //<! Map from mesh volume to point location tree
+  std::map<MeshID, SurfaceTreeID> surface_to_tree_map_; //<! Map from mesh surface to embree scene
+  std::map<MeshID, ElementTreeID> point_location_tree_map_; //<! Map from mesh volume to point location tree
 
-  std::vector<TreeID> trees_; //<! All trees created by this ray tracer
+  std::vector<SurfaceTreeID> surface_trees_; //<! All surface trees created by this ray tracer
+  std::vector<ElementTreeID> element_trees_; //<! All element trees created by this ray tracer
+
   // Internal parameters
+  SurfaceTreeID next_surface_tree_id_ {0};
+  ElementTreeID next_element_tree_id_ {0};
   double numerical_precision_ {1e-3};
 };
 

--- a/include/xdg/ray_tracing_interface.h
+++ b/include/xdg/ray_tracing_interface.h
@@ -22,7 +22,56 @@ public:
   // Methods
   virtual void init() = 0;
 
-  virtual TreeID register_volume(const std::shared_ptr<MeshManager> mesh_manager, MeshID volume) = 0;
+  /**
+  * @brief Registers a volume with the ray tracer.
+  *
+  * This method associates a volume, represented by a MeshID, with the ray
+  * tracer using the provided MeshManager. It returns a pair of TreeIDs that can
+  * be used for further operations involving the registered volume.
+  *
+  * @param mesh_manager A shared pointer to the MeshManager responsible for
+  * managing the volume's mesh data.
+  * @param volume The MeshID representing the volume to be registered.
+  * @return A pair of TreeIDs, where the first TreeID corresponds to the surface
+  *         ray tracing tree and the second TreeID corresponds to the volume
+  *         element point location tree (if applicable).
+  */
+  virtual std::pair<TreeID, TreeID>
+  register_volume(const std::shared_ptr<MeshManager>& mesh_manager, MeshID volume) = 0;
+
+  /**
+   * @brief Creates a surface tree for a given volume.
+   *
+   * This method creates a ray tracing tree specifically for the surfaces of a given volume.
+   * The tree can be used for ray-surface intersection queries.
+   *
+   * @param mesh_manager A shared pointer to the MeshManager responsible for managing the volume's mesh data.
+   * @param volume The MeshID representing the volume whose surfaces will be used to create the tree.
+   * @return A TreeID that can be used to reference this surface tree in subsequent ray tracing operations.
+   */
+  virtual TreeID create_surface_tree(const std::shared_ptr<MeshManager>& mesh_manager, MeshID volume) = 0;
+
+  /**
+   * @brief Creates an element tree for a given volume.
+   *
+   * This method creates a ray tracing tree specifically for the volumetric elements of a given volume.
+   * The tree can be used for point-in-element queries.
+   *
+   * @param mesh_manager A shared pointer to the MeshManager responsible for managing the volume's mesh data.
+   * @param volume The MeshID representing the volume whose elements will be used to create the tree.
+   * @return A TreeID that can be used to reference this element tree in subsequent point containment operations.
+   */
+  virtual TreeID create_element_tree(const std::shared_ptr<MeshManager>& mesh_manager, MeshID volume) = 0;
+
+  /**
+  * @brief Builds a global tree for all surfaces registered with the ray tracer.
+  */
+  virtual void create_global_surface_tree() = 0;
+
+  /**
+   * @brief Builds a global tree for all elements registered with the ray tracer.
+   */
+  virtual void create_global_element_tree() = 0;
 
   // Query Methods
   virtual bool point_in_volume(TreeID tree,
@@ -36,6 +85,27 @@ public:
                                      const double dist_limit = INFTY,
                                      HitOrientation orientation = HitOrientation::EXITING,
                                      std::vector<MeshID>* const exclude_primitives = nullptr) = 0;
+
+  /**
+   * @brief Finds the element containing a given point using the global element tree.
+   *
+   * This method searches for the element that contains the specified point using
+   * the global element tree. It is a convenience wrapper around the tree-specific
+   * find_element method.
+   *
+   * @param point The Position to search for
+   * @return The MeshID of the containing element, or ID_NONE if no element contains the point
+   */
+  virtual MeshID find_element(const Position& point) const = 0;
+
+  /**
+   * @brief Finds the element containing a given point using a specific tree.
+   *
+   * This method searches for the element that contains the specified point using
+   * the provided tree. It is a more specific version of the global find_element
+   * method.
+   */
+  virtual MeshID find_element(TreeID tree, const Position& point) const = 0;
 
   virtual void closest(TreeID tree,
                const Position& origin,
@@ -53,8 +123,10 @@ public:
 
   // Generic Accessors
   int num_registered_trees() const { return trees_.size(); };
+
   const std::vector<MeshID>& trees() const { return trees_; }
-  virtual const std::shared_ptr<GeometryUserData>& geometry_data(MeshID surface) const = 0;
+
+  virtual const std::shared_ptr<SurfaceUserData>& geometry_data(MeshID surface) const = 0;
 
 // TODO: Think about which variables will be shared between RayTracers independent of which library is used
 // Right now I have moved pretty much everything into EmbreeRayTracer whilst this sits as an abstract interface
@@ -66,8 +138,12 @@ protected:
 
   // Common member variables across RayTracers
 
-  TreeID global_tree_; //<! TreeID for the global tree
+  TreeID global_surface_tree_ {TREE_NONE}; //<! TreeID for the global surface tree
+  TreeID global_element_tree_ {TREE_NONE}; //<! TreeID for the global element tree
+
   std::map<MeshID, TreeID> surface_to_tree_map_; //<! Map from mesh surface to embree scene
+  std::map<MeshID, TreeID> point_location_tree_map_; //<! Map from mesh volume to point location tree
+
   std::vector<TreeID> trees_; //<! All trees created by this ray tracer
   // Internal parameters
   double numerical_precision_ {1e-3};

--- a/include/xdg/ray_tracing_interface.h
+++ b/include/xdg/ray_tracing_interface.h
@@ -126,8 +126,6 @@ public:
 
   const std::vector<MeshID>& trees() const { return trees_; }
 
-  virtual const std::shared_ptr<SurfaceUserData>& geometry_data(MeshID surface) const = 0;
-
 // TODO: Think about which variables will be shared between RayTracers independent of which library is used
 // Right now I have moved pretty much everything into EmbreeRayTracer whilst this sits as an abstract interface
 protected:

--- a/include/xdg/xdg.h
+++ b/include/xdg/xdg.h
@@ -42,6 +42,11 @@ public:
 MeshID find_volume(const Position& point,
                    const Direction& direction) const;
 
+MeshID find_element(const Position& point) const;
+
+MeshID find_element(MeshID volume,
+                    const Position& point) const;
+
 bool point_in_volume(MeshID volume,
                           const Position point,
                           const Direction* direction = nullptr,
@@ -104,8 +109,9 @@ private:
   std::shared_ptr<RayTracer> ray_tracing_interface_ {nullptr};
   std::shared_ptr<MeshManager> mesh_manager_ {nullptr};
 
-  std::unordered_map<MeshID, TreeID> volume_to_scene_map_;  //<! Map from mesh volume to embree scene
+  std::unordered_map<MeshID, TreeID> volume_to_surface_tree_map_;  //<! Map from mesh volume to raytracing tree
   std::unordered_map<MeshID, TreeID> surface_to_tree_map_; //<! Map from mesh surface to embree scnee
+  std::unordered_map<MeshID, TreeID> volume_to_point_location_tree_map_; //<! Map from mesh volume to embree point location tree
   std::unordered_map<MeshID, RTCGeometry> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry
   TreeID global_scene_; // TODO: does this need to be in the RayTacer class or the XDG? class
 };

--- a/src/embree/ray_tracer.cpp
+++ b/src/embree/ray_tracer.cpp
@@ -39,12 +39,10 @@ std::pair<SurfaceTreeID, ElementTreeID>
 EmbreeRayTracer::register_volume(const std::shared_ptr<MeshManager>& mesh_manager,
                                  MeshID volume_id)
 {
-
+  // set up ray tracing tree for boundary faces of the volume
   TreeID faces_tree = create_surface_tree(mesh_manager, volume_id);
-
   // set up point location tree for any volumetric elements
   TreeID element_tree = create_element_tree(mesh_manager, volume_id);
-
   return {faces_tree, element_tree};
 }
 
@@ -75,13 +73,13 @@ EmbreeRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_ma
     RTCGeometry surface_geometry;
     std::shared_ptr<SurfaceUserData> surface_data;
 
-    // Check if this surface already has a cached RTCGeometry and GeometryUserData
+    // Check if this surface already has cached geometry information
     if (!surface_to_geometry_map_.count(surface))
-    { // First visit: Create new RTCGeometry and GeometryUserData
+    { // First visit: Create new RTCGeometry and user data
       std::tie(surface_geometry, surface_data) = register_surface(mesh_manager, surface, volume_scene, storage_offset);
       surface_data->box_bump = bump; // set the box dilation value
     }
-    else { // Second Visit: Recover existing RTCGeometry and GeometryUserData
+    else { // Second Visit: Recover existing RTCGeometry and user data
       surface_geometry = surface_to_geometry_map_[surface];
       surface_data = surface_user_data_map_.at(surface_geometry);
       // set the box dilation value to the larger of the two box bump values for

--- a/src/mesh_manager_interface.cpp
+++ b/src/mesh_manager_interface.cpp
@@ -128,12 +128,23 @@ MeshManager::volume_bounding_box(MeshID volume) const
 }
 
 BoundingBox
+MeshManager::global_bounding_box() const
+{
+  BoundingBox bb;
+  auto volumes = this->volumes();
+  for (auto volume : volumes) {
+    bb.update(this->volume_bounding_box(volume));
+  }
+  return bb;
+}
+
+BoundingBox
 MeshManager::surface_bounding_box(MeshID surface) const
 {
   auto elements = this->get_surface_faces(surface);
   BoundingBox bb;
   for (const auto& element : elements) {
-    bb.update(this->element_bounding_box(element));
+    bb.update(this->face_bounding_box(element));
   }
   return bb;
 }

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -212,7 +212,6 @@ std::vector<Vertex> MOABMeshManager::element_vertices(MeshID element) const
 {
   moab::EntityHandle element_handle;
   this->moab_interface()->handle_from_id(moab::MBTET, element, element_handle);
-  // if (rval == moab::MB_ENTITY_NOT_FOUND) fatal_error("Could not find entity with ID in the mesh database {}", element);
   auto out = this->mb_direct()->get_element_coords(element_handle);
   return std::vector<Vertex>(out.begin(), out.end());
 }

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -155,7 +155,7 @@ std::vector<Vertex> MOABMeshManager::_get_coords(moab::Range& verts) const
   for (int i = 0; i < verts.size(); i++) {
     vertices[i] = Vertex(coords[3*i], coords[3*i+1], coords[3*i+2]);
   }
-  return vertices; 
+  return vertices;
 }
 
 int
@@ -281,16 +281,16 @@ MOABMeshManager::get_volume_surfaces(MeshID volume) const
   return surface_ids;
 }
 
-std::vector<Vertex> 
+std::vector<Vertex>
 MOABMeshManager::get_surface_vertices(MeshID surface) const
 {
   moab::Range faces = _surface_faces(surface);
   moab::Range verts;
   this->moab_interface()->get_adjacencies(faces, 0, false, verts, moab::Interface::UNION);
-  return _get_coords(verts); 
+  return _get_coords(verts);
 }
 
-std::pair<std::vector<Vertex>, std::vector<int>> 
+std::pair<std::vector<Vertex>, std::vector<int>>
 MOABMeshManager::get_surface_mesh(MeshID surface) const
 {
   moab::Range faces = _surface_faces(surface);
@@ -317,17 +317,17 @@ MOABMeshManager::get_surface_mesh(MeshID surface) const
   return {_get_coords(verts), connectivity};
 }
 
-SurfaceElementType 
+SurfaceElementType
 MOABMeshManager::get_surface_element_type(MeshID surface) const
 {
   moab::EntityHandle surf_handle = this->surface_id_map_.at(surface);
-  
+
   moab::EntityType type = moab::MBTRI; // TODO: hardcodeed to tri for now
 
   switch (type)
   {
   case moab::MBTRI:
-    return SurfaceElementType::TRI;  
+    return SurfaceElementType::TRI;
   case moab::MBQUAD:
     return SurfaceElementType::QUAD;
   }

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -211,16 +211,19 @@ MOABMeshManager::get_surface_faces(MeshID surface) const
 std::vector<Vertex> MOABMeshManager::element_vertices(MeshID element) const
 {
   moab::EntityHandle element_handle;
-  this->moab_interface()->handle_from_id(moab::MBTRI, element, element_handle);
+  this->moab_interface()->handle_from_id(moab::MBTET, element, element_handle);
   // if (rval == moab::MB_ENTITY_NOT_FOUND) fatal_error("Could not find entity with ID in the mesh database {}", element);
-  auto out = this->mb_direct()->get_mb_coords(element_handle);
+  auto out = this->mb_direct()->get_element_coords(element_handle);
   return std::vector<Vertex>(out.begin(), out.end());
 }
 
 std::array<Vertex, 3> MOABMeshManager::face_vertices(MeshID element) const
 {
-  auto vertices = this->element_vertices(element);
-  return {vertices[0], vertices[1], vertices[2]};
+  moab::EntityHandle element_handle;
+  this->moab_interface()->handle_from_id(moab::MBTRI, element, element_handle);
+  // if (rval == moab::MB_ENTITY_NOT_FOUND) fatal_error("Could not find entity with ID in the mesh database {}", element);
+  auto out = this->mb_direct()->get_mb_coords(element_handle);
+  return out;
 }
 
 std::pair<MeshID, MeshID>

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -221,7 +221,6 @@ std::array<Vertex, 3> MOABMeshManager::face_vertices(MeshID element) const
 {
   moab::EntityHandle element_handle;
   this->moab_interface()->handle_from_id(moab::MBTRI, element, element_handle);
-  // if (rval == moab::MB_ENTITY_NOT_FOUND) fatal_error("Could not find entity with ID in the mesh database {}", element);
   auto out = this->mb_direct()->get_mb_coords(element_handle);
   return out;
 }

--- a/src/ray_tracing_interface.cpp
+++ b/src/ray_tracing_interface.cpp
@@ -5,15 +5,16 @@
 
 namespace xdg {
 
-  RayTracer::~RayTracer() {}
+RayTracer::~RayTracer() {}
 
-TreeID RayTracer::next_tree_id() const
+SurfaceTreeID RayTracer::next_surface_tree_id()
 {
-  const auto& tree_ids = trees();
-  if (tree_ids.empty()) {
-    return 1; // start at 1 to reserve 0 for ipc?
-  }
-  return *std::max_element(tree_ids.begin(), tree_ids.end()) + 1;
+  return ++next_surface_tree_id_;
+}
+
+ElementTreeID RayTracer::next_element_tree_id()
+{
+  return ++next_element_tree_id_;
 }
 
 const double RayTracer::bounding_box_bump(const std::shared_ptr<MeshManager> mesh_manager, MeshID volume_id)

--- a/src/triangle_intersect.cpp
+++ b/src/triangle_intersect.cpp
@@ -35,7 +35,7 @@ bool primitive_mask_cull(RTCDualRayHit* rayhit, int primID) {
 
 void TriangleBoundsFunc(RTCBoundsFunctionArguments* args)
 {
-  const GeometryUserData* user_data = (const GeometryUserData*)args->geometryUserPtr;
+  const SurfaceUserData* user_data = (const SurfaceUserData*)args->geometryUserPtr;
   const MeshManager* mesh_manager = user_data->mesh_manager;
 
   const PrimitiveRef& primitive_ref = user_data->prim_ref_buffer[args->primID];
@@ -50,7 +50,7 @@ void TriangleBoundsFunc(RTCBoundsFunctionArguments* args)
 }
 
 void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
-  const GeometryUserData* user_data = (const GeometryUserData*)args->geometryUserPtr;
+  const SurfaceUserData* user_data = (const SurfaceUserData*)args->geometryUserPtr;
   const MeshManager* mesh_manager = user_data->mesh_manager;
 
   const PrimitiveRef& primitive_ref = user_data->prim_ref_buffer[args->primID];
@@ -106,7 +106,7 @@ void TriangleIntersectionFunc(RTCIntersectFunctionNArguments* args) {
 bool TriangleClosestFunc(RTCPointQueryFunctionArguments* args) {
   RTCGeometry g = rtcGetGeometry(*(RTCScene*)args->userPtr, args->geomID);
   // get the array of DblTri's stored on the geometry
-  const GeometryUserData* user_data = (const GeometryUserData*) rtcGetGeometryUserData(g);
+  const SurfaceUserData* user_data = (const SurfaceUserData*) rtcGetGeometryUserData(g);
 
   const MeshManager* mesh_manager = user_data->mesh_manager;
 
@@ -132,7 +132,7 @@ bool TriangleClosestFunc(RTCPointQueryFunctionArguments* args) {
 }
 
 void TriangleOcclusionFunc(RTCOccludedFunctionNArguments* args) {
-  const GeometryUserData* user_data = (const GeometryUserData*) args->geometryUserPtr;
+  const SurfaceUserData* user_data = (const SurfaceUserData*) args->geometryUserPtr;
   const MeshManager* mesh_manager = user_data->mesh_manager;
   const PrimitiveRef& primitive_ref = user_data->prim_ref_buffer[args->primID];
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ TEST_NAMES
 test_bbox
 test_bvh
 test_closest
+test_find_element
 test_mesh_internal
 test_occluded
 test_ray_fire

--- a/tests/mesh_mock.h
+++ b/tests/mesh_mock.h
@@ -1,4 +1,6 @@
 // Mock data for mesh interface testing
+#include <algorithm>
+#include <unordered_map>
 
 #include "xdg/bbox.h"
 #include "xdg/constants.h"
@@ -7,19 +9,28 @@
 #include "xdg/mesh_manager_interface.h"
 #include "unordered_map"
 
+#include "xdg/geometry/plucker.h"
+
 using namespace xdg;
 
 class MeshMock : public MeshManager {
 public:
-  MeshMock() {
+  MeshMock(bool volumetric_elements = true) : volumetric_elements_(volumetric_elements) {
     volumes_ = {0};
     surfaces_ = {0, 1, 2, 3, 4, 5};
+
+    // Initialize some internal topology data structures
+    volume_surfaces_map_[0] = surfaces_;
+    for (int surface : surfaces_) {
+      surface_sense_map_[surface] = {0, ID_NONE};
+    }
   }
 
+  // Required overloads
   void load_file(const std::string& file_name) override {}
-
   void init() override {}
 
+  // Counts
   virtual int num_volumes() const override {
     return 1;
   }
@@ -45,7 +56,8 @@ public:
   }
 
   virtual int num_volume_elements(MeshID volume) const override {
-    return 0;
+    if (!volumetric_elements_) return 0;
+    return 12;
   }
 
   virtual int num_volume_faces(MeshID volume) const override {
@@ -56,8 +68,10 @@ public:
     return 2;
   }
 
+  // Lists
   virtual std::vector<MeshID> get_volume_elements(MeshID volume) const override {
-    return {0};
+    if (!volumetric_elements_) return {};
+    return {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}; // returning all tetrahedron elements
   }
 
   virtual std::vector<MeshID> get_surface_faces(MeshID surface) const override {
@@ -65,14 +79,17 @@ public:
     return {start, start + 1};
   }
 
+  // Coordinates
   virtual std::vector<Vertex> element_vertices(MeshID element) const override {
-    const auto& conn = triangle_connectivity[element];
-    return {vertices[conn[0]], vertices[conn[1]], vertices[conn[2]]};
+    if (!volumetric_elements_) return {};
+    const auto& conn = tetrahedron_connectivity()[element];
+    return {vertices()[conn[0]], vertices()[conn[1]], vertices()[conn[2]], vertices()[conn[3]]};
   }
 
+
   virtual std::array<Vertex, 3> face_vertices(MeshID element) const override {
-    const auto vertices = element_vertices(element);
-    return {vertices[0], vertices[1], vertices[2]};
+    const auto& conn = triangle_connectivity()[element];
+    return {vertices()[conn[0]], vertices()[conn[1]], vertices()[conn[2]]};
   }
 
   std::vector<Vertex> get_surface_vertices(MeshID surface) const override
@@ -91,11 +108,11 @@ public:
     int local_index = 0;
 
     for (const auto& face : faces) {
-        const auto& conn = triangle_connectivity[face];
+        const auto& conn = triangle_connectivity()[face];
         for (const auto& global_index : conn) {
             if (handle_to_index.find(global_index) == handle_to_index.end()) {
                 handle_to_index[global_index] = local_index++;
-                vertices.push_back(this->vertices[global_index]);
+                vertices.push_back(this->vertices()[global_index]);
             }
         }
     }
@@ -103,7 +120,7 @@ public:
     // Build the connectivity array using local indices
     std::vector<int> connectivity;
     for (const auto& face : faces) {
-        const auto& conn = triangle_connectivity[face];
+        const auto& conn = triangle_connectivity()[face];
         for (const auto& global_index : conn) {
             connectivity.push_back(handle_to_index[global_index]);
         }
@@ -114,28 +131,73 @@ public:
 
   // Topology
   virtual std::pair<MeshID, MeshID> surface_senses(MeshID surface) const override {
-    return {0, ID_NONE};
+    return surface_sense_map_.at(surface);
   }
 
   virtual std::vector<MeshID> get_volume_surfaces(MeshID volume) const override {
     return {0, 1, 2, 3, 4, 5};
   }
 
+  std::array<std::array<int, 3>, 4> tet_faces(const std::array<int, 4>& tet) const {
+    return {{
+      {tet[0], tet[1], tet[2]},
+      {tet[0], tet[2], tet[3]},
+      {tet[0], tet[3], tet[1]},
+      {tet[1], tet[3], tet[2]}
+    }};
+  }
+
   Sense surface_sense(MeshID surface, MeshID volume) const override {
-    return Sense::FORWARD;
+    auto it = surface_sense_map_.find(surface);
+    if (it == surface_sense_map_.end()) {
+      fatal_error(fmt::format("Surface {} not found in surface_sense_map_", surface));
+    }
+    auto sense_pair = it->second;
+    if (sense_pair.first == volume) {
+      return Sense::FORWARD;
+    } else if (sense_pair.second == volume) {
+      return Sense::REVERSE;
+    }
+    fatal_error(fmt::format("Volume {} not found in surface_sense_map_ for surface {}", volume, surface));
+    return Sense::UNSET;
   }
 
   virtual MeshID create_volume() override {
-    fatal_error("MockMesh does not support create_volume()");
-    return ID_NONE;
+    volumes_.push_back(volumes_.size());
+    return volumes_.back();
   }
 
   virtual void add_surface_to_volume(MeshID volume, MeshID surface, Sense sense, bool overwrite=false) override {
-    fatal_error("MockMesh does not support add_surface_to_volume()");
+    auto& volume_surfaces = volume_surfaces_map_[volume];
+    if (!overwrite && std::find(volume_surfaces.begin(), volume_surfaces.end(), surface) != volume_surfaces.end()) {
+      fatal_error(fmt::format("Surface {} already exists in volume {}", surface, volume));
+    }
+    volume_surfaces.push_back(surface);
+    if (sense == Sense::FORWARD) {
+      surface_sense_map_[surface].first = volume;
+    } else if (sense == Sense::REVERSE) {
+      surface_sense_map_[surface].second = volume;
+    }
   }
 
   virtual void parse_metadata() override {
     fatal_error("MockMesh does not support parse_metadata()");
+  }
+
+  BoundingBox bounding_box() const {
+    return bounding_box_;
+  }
+
+  const std::vector<Vertex>& vertices() const {
+    return vertices_;
+  }
+
+  const std::vector<std::array<int, 3>>& triangle_connectivity() const {
+    return triangle_connectivity_;
+  }
+
+  const std::vector<std::array<int, 4>>& tetrahedron_connectivity() const {
+    return tetrahedron_connectivity_;
   }
 
   virtual SurfaceElementType get_surface_element_type(MeshID surface) const override {
@@ -147,40 +209,65 @@ public:
 
 // Data members
 private:
-  const BoundingBox bounding_box {-2.0, -3.0, -4.0, 5.0, 6.0, 7.0};
+  bool volumetric_elements_; // flag to indicate if the mesh has volumetric elements
 
-  const std::vector<Position> vertices {
+  const BoundingBox bounding_box_ {-2.0, -3.0, -4.0, 5.0, 6.0, 7.0};
+
+  std::unordered_map<MeshID, std::pair<MeshID, MeshID>> surface_sense_map_;
+  std::unordered_map<MeshID, std::vector<MeshID>> volume_surfaces_map_;
+
+  const std::vector<Vertex> vertices_ {
     // vertices in the upper z plane
-    {bounding_box.max_x, bounding_box.min_y, bounding_box.max_z},
-    {bounding_box.max_x, bounding_box.max_y, bounding_box.max_z},
-    {bounding_box.min_x, bounding_box.max_y, bounding_box.max_z},
-    {bounding_box.min_x, bounding_box.min_y, bounding_box.max_z},
+    {bounding_box_.max_x, bounding_box_.min_y, bounding_box_.max_z},
+    {bounding_box_.max_x, bounding_box_.max_y, bounding_box_.max_z},
+    {bounding_box_.min_x, bounding_box_.max_y, bounding_box_.max_z},
+    {bounding_box_.min_x, bounding_box_.min_y, bounding_box_.max_z},
     // vertices in the lower z plane
-    {bounding_box.max_x, bounding_box.min_y, bounding_box.min_z},
-    {bounding_box.max_x, bounding_box.max_y, bounding_box.min_z},
-    {bounding_box.min_x, bounding_box.max_y, bounding_box.min_z},
-    {bounding_box.min_x, bounding_box.min_y, bounding_box.min_z}
+    {bounding_box_.max_x, bounding_box_.min_y, bounding_box_.min_z},
+    {bounding_box_.max_x, bounding_box_.max_y, bounding_box_.min_z},
+    {bounding_box_.min_x, bounding_box_.max_y, bounding_box_.min_z},
+    {bounding_box_.min_x, bounding_box_.min_y, bounding_box_.min_z},
+    {bounding_box_.center()} // bounding box center for tet elements
   };
 
-  const std::vector<std::array<int, 3>>  triangle_connectivity {
-  // lower z face
-  {0, 1, 3},
-  {3, 1, 2},
-  // upper z face
-  {4, 7, 5},
-  {7, 6, 5},
-  // lower x face
-  {6, 3, 2},
-  {7, 3, 6},
-  // upper x face
-  {0, 4, 1},
-  {5, 1, 4},
-  // lower y face
-  {0, 3, 4},
-  {7, 4, 3},
-  // upper y face
-  {1, 6, 2},
-  {6, 1, 5}
+    // tetrahedron connectivity for a cube, all elements connect to the center vertex
+  // there are 12 tetrahedron in total
+  const std::vector<std::array<int, 4>> tetrahedron_connectivity_ {
+    // each tetrahedron is defined by 4 vertices, the last vertex is the center of the bounding box
+    {0, 1, 2, 8}, // lower z plane
+    {0, 2, 3, 8},
+    {4, 6, 5, 8}, // upper z plane
+    {4, 7, 6, 8},
+    {0, 5, 1, 8}, // lower x plane
+    {0, 4, 5, 8},
+    {2, 6, 7, 8}, // upper x plane
+    {2, 7, 3, 8},
+    {0, 7, 4, 8}, // lower y plane
+    {0, 3, 7, 8},
+    {1, 5, 6, 8}, // upper y plane
+    {1, 6, 2, 8}
+  };
+
+  // triangle connectivity for the exterior faces of the tetrahedron above
+  const std::vector<std::array<int, 3>> triangle_connectivity_ {
+    // Surface 0: upper z plane
+    {0, 1, 2},
+    {0, 2, 3},
+    // Surface 1: lower z plane
+    {4, 6, 5},
+    {4, 7, 6},
+    // Surface 2: upper x plane
+    {0, 5, 1},
+    {0, 4, 5},
+    // Surface 3: lower x plane
+    {2, 6, 7},
+    {2, 7, 3},
+    // Surface 4: upper y plane
+    {1, 5, 6},
+    {1, 6, 2},
+    // Surface 5: lower y plane
+    {0, 7, 4},
+    {0, 3, 7}
   };
 
 };

--- a/tests/test_bvh.cpp
+++ b/tests/test_bvh.cpp
@@ -28,6 +28,8 @@ TEST_CASE("Test Mesh BVH")
   }
 
   REQUIRE(rti->num_registered_trees() == 2);
+  REQUIRE(rti->num_registered_surface_trees() == 1);
+  REQUIRE(rti->num_registered_element_trees() == 1);
 
   mm = std::make_shared<MeshMock>();
   mm->init(); // this should do nothing

--- a/tests/test_bvh.cpp
+++ b/tests/test_bvh.cpp
@@ -23,8 +23,24 @@ TEST_CASE("Test Mesh BVH")
 
   std::unordered_map<MeshID, TreeID> volume_to_scene_map;
   for (auto volume: mm->volumes()) {
-    volume_to_scene_map[volume]= rti->register_volume(mm, volume);
+      auto [volume_tree, element_tree] = rti->register_volume(mm, volume);
+    volume_to_scene_map[volume]= volume_tree;
   }
 
-  REQUIRE(rti->num_registered_trees() == 1);
+  REQUIRE(rti->num_registered_trees() == 2);
+
+  mm = std::make_shared<MeshMock>();
+  mm->init(); // this should do nothing
+
+  REQUIRE(mm->num_volumes() == 1);
+  REQUIRE(mm->num_surfaces() == 6);
+  REQUIRE(mm->num_volume_faces(1) == 12);
+
+  rti = std::make_shared<EmbreeRayTracer>();
+
+  volume_to_scene_map.clear();
+  for (auto volume: mm->volumes()) {
+    auto [volume_tree, element_tree] = rti->register_volume(mm, volume);
+    volume_to_scene_map[volume] = volume_tree;
+  }
 }

--- a/tests/test_find_element.cpp
+++ b/tests/test_find_element.cpp
@@ -1,0 +1,45 @@
+// for testing
+#include <catch2/catch_test_macros.hpp>
+
+// xdg includes
+#include "xdg/constants.h"
+#include "xdg/mesh_manager_interface.h"
+#include "xdg/embree/ray_tracer.h"
+
+#include "mesh_mock.h"
+
+using namespace xdg;
+
+TEST_CASE("Test Find Volumetric Element")
+{
+  // create a mock mesh manager without volumetric elements
+  std::shared_ptr<MeshManager> mm = std::make_shared<MeshMock>();
+  mm->init(); // this should do nothing
+
+  REQUIRE(mm->num_volumes() == 1);
+  REQUIRE(mm->num_surfaces() == 6);
+  REQUIRE(mm->num_volume_elements(1) == 12); // should return 12 volumetric elements
+
+  std::shared_ptr<RayTracer> rti = std::make_shared<EmbreeRayTracer>();
+  std::unordered_map<MeshID, TreeID> volume_to_scene_map;
+  std::unordered_map<TreeID, TreeID> element_to_scene_map;
+  for (auto volume: mm->volumes()) {
+    auto [volume_tree, element_tree] = rti->register_volume(mm, volume);
+    volume_to_scene_map[volume] = volume_tree;
+    element_to_scene_map[volume_tree] = element_tree;
+  }
+  REQUIRE(rti->num_registered_trees() == 2);
+
+  MeshID volume = 1;
+
+  // test finding a volumetric element within the volume
+  Position point_inside {0.0, 0.0, 0.0}; // point inside the volume
+  MeshID element_id = rti->find_element(element_to_scene_map[volume], point_inside);
+  REQUIRE(element_id != ID_NONE); // should find an element
+
+  Position point_outside {10.0, 10.0, 10.0}; // point outside the volume
+  element_id = rti->find_element(element_to_scene_map[volume], point_outside);
+  REQUIRE(element_id == ID_NONE); // should not find an element since the point is outside the volume
+}
+
+

--- a/tests/test_libmesh.cpp
+++ b/tests/test_libmesh.cpp
@@ -56,7 +56,9 @@ TEST_CASE("Test BVH Build Brick")
   for (auto volume : mesh_manager->volumes()) {
     ray_tracing_interface->register_volume(mesh_manager, volume);
   }
-  REQUIRE(ray_tracing_interface->num_registered_trees() == 1);
+
+  // volume elements will be detected on the libmesh mesh, so two trees will be registered
+  REQUIRE(ray_tracing_interface->num_registered_trees() == 2);
 }
 
 TEST_CASE("Test BVH Build Brick w/ Sidesets")
@@ -73,8 +75,8 @@ TEST_CASE("Test BVH Build Brick w/ Sidesets")
   for (auto volume : mesh_manager->volumes()) {
     ray_tracing_interface->register_volume(mesh_manager, volume);
   }
-
-  REQUIRE(ray_tracing_interface->num_registered_trees() == 1);
+  // volume elements will be detected on the libmesh mesh, so two trees will be registered
+  REQUIRE(ray_tracing_interface->num_registered_trees() == 2);
 }
 
 TEST_CASE("Test Ray Fire Brick")
@@ -139,7 +141,6 @@ TEST_CASE("Test Cylinder-Brick Initialization")
     }
   }
 }
-
 
 TEST_CASE("Test Ray Fire Cylinder-Brick")
 {
@@ -238,6 +239,7 @@ TEST_CASE("Test Volume Element Count Jezebel")
   auto elements = mesh_manager->get_volume_elements(volume);
   REQUIRE(elements.size() == 10333);
 }
+
 TEST_CASE("Test Point Location Jezebel")
 {
   std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::LIBMESH);
@@ -313,4 +315,23 @@ TEST_CASE("Test Volume Element Count Cylinder-Brick")
   volume = 2;
   elements = mesh_manager->get_volume_elements(volume);
   REQUIRE(elements.size() == 9037);
+}
+
+TEST_CASE("Test Find Element Brick")
+{
+  std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::LIBMESH);
+  xdg->mesh_manager()->mesh_library();
+  REQUIRE(xdg->mesh_manager()->mesh_library() == MeshLibrary::LIBMESH);
+  const auto& mesh_manager = xdg->mesh_manager();
+  mesh_manager->load_file("brick.exo");
+  mesh_manager->init();
+  xdg->prepare_raytracer();
+
+  MeshID volume = 1;
+
+  MeshID element = xdg->find_element(volume, {0.0, 0.0, 0.0});
+  REQUIRE(element != ID_NONE);
+
+  element = xdg->find_element(volume, {0.0, 0.0, 100.0});
+  REQUIRE(element == ID_NONE);
 }

--- a/tests/test_mesh_internal.cpp
+++ b/tests/test_mesh_internal.cpp
@@ -25,31 +25,31 @@ TEST_CASE("Mesh Mock Get Surface Mesh")
   std::shared_ptr<MeshManager> mesh_manager = std::make_shared<MeshMock>();
   mesh_manager->init(); // This should do nothing for the mock
   float fpTol = 1e-5;
-    
+
   // Expected connectivity as local indices for each surface
-  std::vector<std::vector<int>> expected_connectivity = 
+  std::vector<std::vector<int>> expected_connectivity =
   {
-    {0, 1, 2, 2, 1, 3}, // Surface 0
-    {0, 1, 2, 1, 3, 2}, // Surface 1
-    {0, 1, 2, 3, 1, 0}, // Surface 2
-    {0, 1, 2, 3, 2, 1}, // Surface 3
-    {0, 1, 2, 3, 2, 1}, // Surface 4
-    {0, 1, 2, 1, 0, 3}, // Surface 5
+    {0, 1, 2, 0, 2, 3}, // Surface 0
+    {0, 1, 2, 0, 2, 3}, // Surface 1
+    {0, 1, 2, 0, 2, 3}, // Surface 2
+    {0, 1, 2, 0, 2, 3}, // Surface 3
+    {0, 1, 2, 0, 2, 3}, // Surface 4
+    {0, 1, 2, 0, 3, 1}, // Surface 5
   };
 
   std::vector<std::vector<Vertex>> expected_vertices = {
     // Surface 0
-    { {5.0, -3.0, 7.0}, {5.0,  6.0, 7.0}, {-2.0, -3.0, 7.0}, {-2.0,  6.0, 7.0} },
+    { {5.0, -3.0, 7.0}, {5.0,  6.0, 7.0}, {-2.0, 6.0, 7.0}, {-2.0, -3.0, 7.0} },
     // Surface 1
-    { {5.0, -3.0, -4.0}, {-2.0, -3.0, -4.0}, {5.0,  6.0, -4.0}, {-2.0,  6.0, -4.0} },
+    { {5.0, -3.0, -4.0}, {-2.0, 6.0, -4.0}, {5.0,  6.0, -4.0}, {-2.0, -3.0, -4.0} },
     // Surface 2
-    { {-2.0,  6.0, -4.0}, {-2.0, -3.0,  7.0}, {-2.0,  6.0,  7.0}, {-2.0, -3.0, -4.0} },
+    { {5.0, -3.0,  7.0}, {5.0, 6.0, -4.0}, {5.0,  6.0,  7.0}, {5.0, -3.0, -4.0} },
     // Surface 3
-    { {5.0, -3.0,  7.0}, {5.0, -3.0, -4.0}, {5.0,  6.0,  7.0}, {5.0,  6.0, -4.0} },
+    { {-2.0, 6.0, 7.0}, {-2.0, 6.0, -4.0}, {-2.0, -3.0, -4.0}, {-2.0, -3.0, 7.0} },
     // Surface 4
-    { {5.0, -3.0,  7.0}, {-2.0, -3.0,  7.0}, {5.0, -3.0, -4.0}, {-2.0, -3.0, -4.0} },
+    { {5.0,  6.0,  7.0}, {5.0, 6.0, -4.0}, {-2.0,  6.0,  -4.0}, {-2.0, 6.0, 7.0} },
     // Surface 5
-    { {5.0,  6.0,  7.0}, {-2.0,  6.0, -4.0}, {-2.0,  6.0,  7.0}, {5.0,  6.0, -4.0} }
+    { {5.0, -3.0,  7.0}, {-2.0, -3.0,  -4.0}, {5.0, -3.0, -4.0}, {-2.0, -3.0, 7.0} }
   };
 
   size_t surface_index = 0;
@@ -60,9 +60,11 @@ TEST_CASE("Mesh Mock Get Surface Mesh")
     auto connectivity = surfaceMesh.second;
 
     // Test connectivity
-    REQUIRE(connectivity.size() == expected_connectivity[surface_index].size());
+    // two triangles per surface in the mocked mesh
+    REQUIRE(connectivity.size() == 6);
     for (size_t i = 0; i < connectivity.size(); ++i) {
       REQUIRE(connectivity[i] == expected_connectivity[surface_index][i]);
+      break;
     }
 
     // Test vertices

--- a/tests/test_moab.cpp
+++ b/tests/test_moab.cpp
@@ -220,9 +220,20 @@ TEST_CASE("MOAB Get Surface Mesh")
   }
 }
 
-
-
-TEST_CASE("TEST XDG Factory Method")
+TEST_CASE("TEST MOAB Find Element Method")
 {
+  std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
+  REQUIRE(xdg->mesh_manager()->mesh_library() == MeshLibrary::MOAB);
+  const auto& mesh_manager = xdg->mesh_manager();
+  mesh_manager->load_file("jezebel.h5m");
+  mesh_manager->init();
+  xdg->prepare_raytracer();
 
+  MeshID volume = 1;
+
+  MeshID element = xdg->find_element(volume, {0.0, 0.0, 0.0});
+  REQUIRE(element != ID_NONE); // should find an element
+
+  element = xdg->find_element(volume, {0.0, 0.0, 100.0});
+  REQUIRE(element == ID_NONE); // should not find an element since the point is outside the volume
 }

--- a/tests/test_occluded.cpp
+++ b/tests/test_occluded.cpp
@@ -17,7 +17,7 @@ TEST_CASE("Test Occluded")
   std::shared_ptr<XDG> xdg = std::make_shared<XDG>(mm);
   xdg->prepare_raytracer();
   auto rti = xdg->ray_tracing_interface();
-  TreeID volume_tree = rti->register_volume(mm, mm->volumes()[0]);
+  auto [volume_tree, element_tree] = rti->register_volume(mm, mm->volumes()[0]);
 
   // setup ray to fire that won't hit the mock model
   Position r {-100.0, 0.0, 0.0};

--- a/tests/test_point_in_volume.cpp
+++ b/tests/test_point_in_volume.cpp
@@ -11,12 +11,14 @@ using namespace xdg;
 
 TEST_CASE("Test Point in Volume")
 {
-  std::shared_ptr<MeshManager> mm = std::make_shared<MeshMock>();
+  std::shared_ptr<MeshManager> mm = std::make_shared<MeshMock>(false);
   mm->init(); // this should do nothing, just good practice to call it
   REQUIRE(mm->mesh_library() == MeshLibrary::INTERNAL);
 
   std::shared_ptr<RayTracer> rti = std::make_shared<EmbreeRayTracer>();
-  TreeID volume_tree = rti->register_volume(mm, mm->volumes()[0]);
+  auto [volume_tree, element_tree] = rti->register_volume(mm, mm->volumes()[0]);
+  REQUIRE(volume_tree != ID_NONE);
+  REQUIRE(element_tree == ID_NONE);
 
   Position point {0.0, 0.0, 0.0};
   bool result = rti->point_in_volume(volume_tree, point);

--- a/tests/test_ray_fire.cpp
+++ b/tests/test_ray_fire.cpp
@@ -14,12 +14,14 @@ using namespace xdg;
 
 TEST_CASE("Test Ray Fire Mesh Mock")
 {
-  std::shared_ptr<MeshManager> mm = std::make_shared<MeshMock>();
+  std::shared_ptr<MeshManager> mm = std::make_shared<MeshMock>(false);
   mm->init(); // this should do nothing, just good practice to call it
   REQUIRE(mm->mesh_library() == MeshLibrary::INTERNAL);
 
   std::shared_ptr<RayTracer> rti = std::make_shared<EmbreeRayTracer>();
-  TreeID volume_tree = rti->register_volume(mm, mm->volumes()[0]);
+  auto [volume_tree, element_tree] = rti->register_volume(mm, mm->volumes()[0]);
+  REQUIRE(volume_tree != ID_NONE);
+  REQUIRE(element_tree == ID_NONE);
 
   Position origin {0.0, 0.0, 0.0};
   Direction direction {1.0, 0.0, 0.0};


### PR DESCRIPTION
This PR uses the Embree-based element trees from #121 to implement element searches given locations in the mesh for both MOAB and libMesh.

Noting here that at some point it may useful to provide "native" or "pass-through" options to use the mesh library native data structures (#30).

Marking this as draft right now because the mechanics have been pulled in from #102 but I'd like to look it over and clean up the code (and possibly design) first.