### PR TITLE
libMesh initialization fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
         run: |
           echo "MOAB_SHA"=$(cd ~/moab && git rev-parse HEAD) >> $GITHUB_ENV
           echo "LIBMESH_SHA"=$(cd ~/libmesh && git rev-parse HEAD) >> $GITHUB_ENV
+          # Enforce that we're using the debug build of libMesh
+          echo "METHOD=dbg" >> $GITHUB_ENV
 
       - name: MOAB Cache
         id: moab-cache

--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -22,7 +22,7 @@ public:
 
   LibMeshManager();
 
-  ~LibMeshManager();
+  ~LibMeshManager() override = default;
 
   // Backend methods
 
@@ -295,9 +295,10 @@ public:
 
   // Attributes
   protected:
-  std::unique_ptr<libMesh::Mesh> mesh_ {nullptr};
   // TODO: make this global so it isn't owned by a single mesh manager
   std::unique_ptr<libMesh::LibMeshInit> libmesh_init {nullptr};
+  // this attribute must come after libmesh_init so that it is destroyed last
+  std::unique_ptr<libMesh::Mesh> mesh_ {nullptr};
 
   // Ugh, double mapping
   std::unordered_map<MeshID, SidePair> mesh_id_to_sidepair_;

--- a/include/xdg/mesh_manager_interface.h
+++ b/include/xdg/mesh_manager_interface.h
@@ -15,6 +15,7 @@ class MeshManager {
 public:
 
   // Abstract Methods
+  virtual ~MeshManager() = default;
 
   // Setup
   virtual void load_file(const std::string& filepath) = 0;

--- a/src/libmesh/mesh_manager.cpp
+++ b/src/libmesh/mesh_manager.cpp
@@ -29,11 +29,6 @@ void LibMeshManager::load_file(const std::string &filepath) {
   mesh_->read(filepath);
 }
 
-LibMeshManager::~LibMeshManager() {
-  if (mesh_ != nullptr) mesh_->clear();
-  libmesh_init.reset();
-}
-
 void LibMeshManager::initialize_libmesh() {
   // libmesh requires the program name, so at least one argument is needed
   int argc = 1;


### PR DESCRIPTION
I noticed when building against a debug version of libMesh that we are triggering some assertions in testing due to the way the `LibMeshManager` deconstructor is formed.

An example of this happening in CI is here from the first commit in this branch:

https://github.com/pshriwise/xdg/actions/runs/15625258511/job/44018149010

This PR corrects the issues with the constructor and attribute ordering in the `LibMeshManger` class. It also sets the `METHOD` environment variable to `dbg` in CI, which will ensure that such assertions are triggered in CI in the future. I'm okay with linking against a debug build here b/c we're more concerned with correctness/consistency in CI than performance.