### PR TITLE
Added in structured bindings in various places for clearer intent

### DIFF
--- a/src/libmesh/mesh_manager.cpp
+++ b/src/libmesh/mesh_manager.cpp
@@ -96,17 +96,17 @@ MeshID LibMeshManager::create_volume() {
 }
 
 void LibMeshManager::add_surface_to_volume(MeshID volume, MeshID surface, Sense sense, bool overwrite) {
-    auto senses = surface_senses(surface);
+    auto [forward_sense, reverse_sense] = surface_senses(surface);
     if (sense == Sense::FORWARD) {
-      if (!overwrite && senses.first != ID_NONE) {
+      if (!overwrite && forward_sense != ID_NONE) {
         fatal_error("Surface already has a forward sense");
       }
-      surface_senses_[surface] = {volume, senses.second};
+      surface_senses_[surface] = {volume, reverse_sense};
     } else {
-      if (!overwrite && senses.second != ID_NONE) {
+      if (!overwrite && reverse_sense != ID_NONE) {
         fatal_error("Surface already has a reverse sense");
       }
-      surface_senses_[surface] = {senses.first, volume};
+      surface_senses_[surface] = {forward_sense, volume};
     }
 }
 
@@ -373,8 +373,8 @@ LibMeshManager::surface_senses(MeshID surface) const {
 }
 
 Sense LibMeshManager::surface_sense(MeshID surface, MeshID volume) const {
-  auto senses = surface_senses(surface);
-  return volume == senses.first ? Sense::FORWARD : Sense::REVERSE;
+  auto [forward_sense, reverse_sense] = surface_senses(surface);
+  return volume == forward_sense ? Sense::FORWARD : Sense::REVERSE;
 }
 
 } // namespace xdg

--- a/src/mesh_manager_interface.cpp
+++ b/src/mesh_manager_interface.cpp
@@ -14,12 +14,12 @@ MeshManager::create_implicit_complement()
   MeshID ipc_volume = this->create_volume();
 
   for (auto surface : this->surfaces()) {
-    auto parent_vols = this->get_parent_volumes(surface);
+    auto [forward_parent, reverse_parent] = this->get_parent_volumes(surface);
 
-  if (parent_vols.first == ID_NONE)
+  if (forward_parent == ID_NONE)
       this->add_surface_to_volume(ipc_volume, surface, Sense::FORWARD);
 
-    if (parent_vols.second == ID_NONE)
+    if (reverse_parent == ID_NONE)
       this->add_surface_to_volume(ipc_volume, surface, Sense::REVERSE);
   }
 
@@ -84,12 +84,12 @@ MeshManager::get_surface_property(MeshID surface, PropertyType type) const
 
 MeshID MeshManager::next_volume(MeshID current_volume, MeshID surface) const
 {
-  auto parent_vols = this->get_parent_volumes(surface);
+  auto [forward_parent, reverse_parent] = this->get_parent_volumes(surface);
 
-  if (parent_vols.first == current_volume)
-    return parent_vols.second;
-  else if (parent_vols.second == current_volume)
-    return parent_vols.first;
+  if (forward_parent == current_volume)
+    return reverse_parent;
+  else if (reverse_parent == current_volume)
+    return forward_parent;
   else
     fatal_error("Volume {} is not a parent of surface {}", current_volume, surface);
 

--- a/src/xdg.cpp
+++ b/src/xdg.cpp
@@ -92,9 +92,7 @@ bool XDG::point_in_volume(MeshID volume,
 MeshID XDG::find_volume(const Position& point,
                                                    const Direction& direction) const
 {
-  for (auto volume_scene_pair : volume_to_scene_map_) {
-    MeshID volume = volume_scene_pair.first;
-    TreeID scene = volume_scene_pair.second;
+  for (auto [volume, scene] : volume_to_scene_map_) {
     if (ray_tracing_interface()->point_in_volume(scene, point, &direction)) {
       return volume;
     }
@@ -148,9 +146,9 @@ Direction XDG::surface_normal(MeshID surface,
   if (exclude_primitives != nullptr && exclude_primitives->size() > 0) {
     element = exclude_primitives->back();
   } else {
-    auto surface_vols = mesh_manager()->get_parent_volumes(surface);
+    auto [forward_parent, reverse_parent] = mesh_manager()->get_parent_volumes(surface);
     double dist;
-    TreeID scene = volume_to_scene_map_.at(surface_vols.first);
+    TreeID scene = volume_to_scene_map_.at(forward_parent);
     ray_tracing_interface()->closest(scene, point, dist, element);
 
     // TODO: bring this back when we have a better way to handle this

--- a/tests/test_cross_check.cpp
+++ b/tests/test_cross_check.cpp
@@ -22,9 +22,9 @@ public:
 
     // Methods
     void transport() {
-      for (const auto& test_case : test_cases_) {
-        std::shared_ptr<XDG> xdg {XDG::create(test_case.second)};
-        xdg->mesh_manager()->load_file(test_case.first);
+      for (const auto& [filename, mesh_library] : test_cases_) {
+        std::shared_ptr<XDG> xdg {XDG::create(mesh_library)};
+        xdg->mesh_manager()->load_file(filename);
         xdg->mesh_manager()->init();
         xdg->mesh_manager()->parse_metadata();
         xdg->prepare_raytracer();

--- a/tests/test_mesh_internal.cpp
+++ b/tests/test_mesh_internal.cpp
@@ -26,8 +26,8 @@ TEST_CASE("Mesh Mock Get Surface Mesh")
   mesh_manager->init(); // This should do nothing for the mock
   float fpTol = 1e-5;
     
-  // Expected connectivity as local indices for each surface
-  std::vector<std::vector<int>> expected_connectivity = 
+  // Expected indices as local indices for each surface
+  std::vector<std::vector<int>> expected_indices = 
   {
     {0, 1, 2, 2, 1, 3}, // Surface 0
     {0, 1, 2, 1, 3, 2}, // Surface 1
@@ -53,16 +53,14 @@ TEST_CASE("Mesh Mock Get Surface Mesh")
   };
 
   size_t surface_index = 0;
-  // Loop over every surface in the MeshMock and test the connectivity and vertices
+  // Loop over every surface in the MeshMock and test the indices and vertices
   for (const auto surface : mesh_manager->surfaces()) {
-    auto surfaceMesh = mesh_manager->get_surface_mesh(surface);
-    auto vertices = surfaceMesh.first;
-    auto connectivity = surfaceMesh.second;
+    auto [vertices, indices] = mesh_manager->get_surface_mesh(surface);
 
-    // Test connectivity
-    REQUIRE(connectivity.size() == expected_connectivity[surface_index].size());
-    for (size_t i = 0; i < connectivity.size(); ++i) {
-      REQUIRE(connectivity[i] == expected_connectivity[surface_index][i]);
+    // Test indices
+    REQUIRE(indices.size() == expected_indices[surface_index].size());
+    for (size_t i = 0; i < indices.size(); ++i) {
+      REQUIRE(indices[i] == expected_indices[surface_index][i]);
     }
 
     // Test vertices

--- a/tests/test_moab.cpp
+++ b/tests/test_moab.cpp
@@ -135,8 +135,8 @@ TEST_CASE("MOAB Get Surface Mesh")
 
   float fpTol = 1e-5;
 
-  // Define the expected connectivity and vertices for each surface
-  std::vector<std::vector<int>> expected_connectivity = {
+  // Define the expected indices and vertices for each surface
+  std::vector<std::vector<int>> expected_indices = {
       {2, 3, 5, 3, 0, 4, 5, 4, 1, 3, 4, 5},                   /* Surface 1 */
       {5, 4, 1, 4, 7, 3, 2, 3, 6, 4, 5, 7, 5, 0, 7, 7, 6, 3}, /* Surface 2 */
       {5, 0, 7, 5, 4, 2, 1, 3, 6, 3, 4, 7, 4, 5, 7, 3, 7, 6}, /* Surface 3 */
@@ -198,14 +198,12 @@ TEST_CASE("MOAB Get Surface Mesh")
 
   size_t surface_index = 0;
   for (const auto surface : mesh_manager->surfaces()) {
-    auto surfaceMesh = mesh_manager->get_surface_mesh(surface);
-    auto vertices = surfaceMesh.first;
-    auto connectivity = surfaceMesh.second;
+    auto [vertices, indices] = mesh_manager->get_surface_mesh(surface);
 
-    // Test connectivity
-    REQUIRE(connectivity.size() == expected_connectivity[surface_index].size());
-    for (size_t i = 0; i < connectivity.size(); ++i) {
-      REQUIRE(connectivity[i] == expected_connectivity[surface_index][i]);
+    // Test indices
+    REQUIRE(indices.size() == expected_indices[surface_index].size());
+    for (size_t i = 0; i < indices.size(); ++i) {
+      REQUIRE(indices[i] == expected_indices[surface_index][i]);
     }
 
     // Test vertices

--- a/tools/ray_fire.cpp
+++ b/tools/ray_fire.cpp
@@ -71,10 +71,10 @@ int main(int argc, char** argv) {
   std::cout << "Origin: " << origin[0] << ", " << origin[1] << ", " << origin[2] << std::endl;
   std::cout << "Direction: " << direction[0] << ", " << direction[1] << ", " << direction[2] << std::endl;
 
-  auto result = xdg->ray_fire(volume, origin, direction);
+  auto [distance, surface] = xdg->ray_fire(volume, origin, direction);
 
-  std::cout << "Distance: " << result.first << std::endl;
-  std::cout << "Surface: " << result.second << std::endl;
+  std::cout << "Distance: " << distance << std::endl;
+  std::cout << "Surface: " << surface << std::endl;
 
   return 0;
 }


### PR DESCRIPTION
PR for #127 

Replaced some instances of `std::pair::first` and `std::pair::second` with structured bindings where I deemed appropriate. There have been a couple places where I haven't bothered to make the change, namely: 

- `libmesh/mesh_manager.h` and `libmesh/mesh_manager.cpp` the `SidePair` struct which extensively makes use of `.first`/`.second` syntax which I think won't be worth overhauling in favour of `structured bindings`.
- `tools/particle_sim.h` defines a struct `Particle` which has a member variable `surface_intersection_` which is repeatedly used to store the results of `xdg::ray_fire()`. Usage of the member variable directly probably makes more sense here.
- `test_moab.cpp` and `test_ray_fire.cpp` also make use of a similar pattern with defining an `intersection` variable which is consistently reused for `ray_fire()` results.
- Inside `embree/ray_tracer.cpp` the `EmbreeRayTracer::register_volume()` there is a case where it makes sense for `structured binding` but I already refactor this entire function in #57. - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 