### PR TITLE
MOAB direct access refactor

### DIFF
--- a/include/xdg/moab/direct_access.h
+++ b/include/xdg/moab/direct_access.h
@@ -63,68 +63,12 @@ public:
     return vertices;
   }
 
-  //! \brief Get the adjacent element
-  inline EntityHandle get_adjacent_element(const EntityHandle& element, int face_number) {
-    return adjacenty_data_.get_adjacent_element(element, face_number);
-  }
-
   // Accessors
   //! \brief return the number of vertices being managed
   inline int n_vertices() { return vertex_data_.num_vertices; }
 
 private:
   Interface* mbi {nullptr}; //!< MOAB instance for the managed data
-
-  struct AdjacencyData {
-    EntityType entity_type {MBMAXTYPE}; //!< Type of entity stored in this manager
-    int num_entities {-1}; //!< Number of elements in the manager
-    std::unordered_map<EntityHandle, std::vector<EntityHandle>> adj_info_;
-
-
-    void setup(Interface* mbi) {
-      ErrorCode rval;
-
-      // setup element adjacenty data
-      // TODO: support other element types
-      Range elements;
-      rval = mbi->get_entities_by_type(0, entity_type, elements, true);
-      MB_CHK_SET_ERR_CONT(rval, "Failed to get MOAB element adjacencies");
-
-      // loop over elements and setup adjacency data
-      for (auto element : elements) {
-        // get element connectivity
-        std::vector<EntityHandle> conn;
-        rval = mbi->get_connectivity(&element, 1, conn);
-
-        // use ordering and adjacency call with intersection to populate adjacency entry
-        for (auto o : ordering[entity_type]) {
-          // determine element for this face
-          std::vector<EntityHandle> verts;
-          for (auto idx : o) verts.push_back(conn[idx]);
-          Range adj_ents;
-          rval = mbi->get_adjacencies(verts.data(), verts.size(), 3, true, adj_ents);
-          if (adj_ents.size() != 1) {
-            throw std::runtime_error("Something went wrong gathering adjacent face");
-          }
-          adj_info_[element].push_back(adj_ents[0]);
-        }
-      }
-    }
-
-    EntityHandle get_adjacent_element(const EntityHandle& element, int face_number) {
-      return adj_info_[element][face_number];
-    }
-
-    void clear() {
-      num_entities = -1;
-      adj_info_.clear();
-    }
-
-    std::unordered_map<EntityType, std::vector<std::vector<int>>> ordering = {
-    {MBTET, {{0, 1, 3}, {1, 2, 3}, {2, 0, 3}, {0, 2, 1}}}
-    };
-};
-
   struct ConnectivityData {
     EntityType entity_type {MBMAXTYPE}; //!< Type of entity stored in this manager
     int num_entities {-1}; //!< Number of elements in the manager
@@ -244,7 +188,6 @@ private:
 
   ConnectivityData face_data_;
   ConnectivityData element_data_;
-  AdjacencyData adjacenty_data_;
   VertexData vertex_data_;
 };
 

--- a/include/xdg/moab/direct_access.h
+++ b/include/xdg/moab/direct_access.h
@@ -29,37 +29,37 @@ public:
 
   //! \brief Check that a triangle is part of the managed coordinates here
   inline bool accessible(EntityHandle tri) {
-    // determine the correct index to use
-    int idx = 0;
-    auto fe = face_data_.first_elements[idx];
+    // determine the correct contiguous memory block index to use
+    int block_idx = 0;
+    auto fe = face_data_.first_elements[block_idx];
     while(true) {
       if (tri - fe.first < fe.second) { break; }
-      idx++;
-      if (idx >= face_data_.first_elements.size()) { return false; }
-      fe = face_data_.first_elements[idx];
+      block_idx++;
+      if (block_idx >= face_data_.first_elements.size()) { return false; }
+      fe = face_data_.first_elements[block_idx];
     }
     return true;
   }
 
   //! \brief Get the coordinates of a triangle as MOAB CartVect's
   inline std::array<xdg::Vertex, 3> get_mb_coords(const EntityHandle& tri) {
-    auto [idx, i0, i1, i2] = face_data_.get_connectivity_indices(tri);
+    auto [block_idx, i0, i1, i2] = face_data_.get_connectivity_indices(tri);
 
     std::array<xdg::Vertex, 3> vertices;
-    vertex_data_.set_coords(idx, i0, vertices[0]);
-    vertex_data_.set_coords(idx, i1, vertices[1]);
-    vertex_data_.set_coords(idx, i2, vertices[2]);
+    vertex_data_.set_coords(block_idx, i0, vertices[0]);
+    vertex_data_.set_coords(block_idx, i1, vertices[1]);
+    vertex_data_.set_coords(block_idx, i2, vertices[2]);
     return vertices;
   }
 
   //! \brief Get the coordinates of a triangle as MOAB CartVect's
   inline std::array<xdg::Vertex, 3> get_element_coords(const EntityHandle& element) {
-    auto [idx, i0, i1, i2] = element_data_.get_connectivity_indices(element);
+    auto [block_idx, i0, i1, i2] = element_data_.get_connectivity_indices(element);
 
     std::array<xdg::Vertex, 3> vertices;
-    vertex_data_.set_coords(idx, i0, vertices[0]);
-    vertex_data_.set_coords(idx, i1, vertices[1]);
-    vertex_data_.set_coords(idx, i2, vertices[2]);
+    vertex_data_.set_coords(block_idx, i0, vertices[0]);
+    vertex_data_.set_coords(block_idx, i1, vertices[1]);
+    vertex_data_.set_coords(block_idx, i2, vertices[2]);
     return vertices;
   }
 
@@ -107,23 +107,22 @@ private:
 
     std::array<size_t, 4>
     get_connectivity_indices(const EntityHandle& e) {
-      // determine the correct index to use
-      int idx = 0;
-      auto fe = first_elements[idx];
+      // determine the correct contiguous block index to use
+      int block_idx = 0;
+      auto fe = first_elements[block_idx];
       while(true) {
         if (e - fe.first < fe.second) { break; }
-        idx++;
-        // if (idx >= first_elements.size()) { return {-1, -1, -1, -1}; }
-        fe = first_elements[idx];
+        block_idx++;
+        fe = first_elements[block_idx];
       }
 
       std::array<size_t, 4> indices;
-      indices[0] = idx;
+      indices[0] = block_idx;
 
       size_t conn_idx = element_stride * (e - fe.first);
-      indices[1] = vconn[idx][conn_idx] - 1;
-      indices[2] = vconn[idx][conn_idx + 1] - 1;
-      indices[3] = vconn[idx][conn_idx + 2] - 1;
+      indices[1] = vconn[block_idx][conn_idx] - 1;
+      indices[2] = vconn[block_idx][conn_idx + 1] - 1;
+      indices[3] = vconn[block_idx][conn_idx + 2] - 1;
       return indices;
     }
 
@@ -178,7 +177,6 @@ private:
     void set_coords(int idx, int i, xdg::Vertex& v) {
       v = xdg::Vertex(tx[idx][i], ty[idx][i], tz[idx][i]);
     }
-
 
     int num_vertices {-1}; //!< Number of vertices in the manager
     std::vector<const double*> tx; //!< Storage array(s) for vertex x coordinates

--- a/src/moab/direct_access.cpp
+++ b/src/moab/direct_access.cpp
@@ -10,7 +10,6 @@ MBDirectAccess::MBDirectAccess(Interface* mbi)
 {
   face_data_.entity_type = MBTRI;
   element_data_.entity_type = MBTET;
-  adjacenty_data_.entity_type = MBTET;
   setup();
 }
 
@@ -18,8 +17,6 @@ void
 MBDirectAccess::setup() {
   face_data_.setup(mbi);
   element_data_.setup(mbi);
-  // TODO: fix adjacency setup for MOAB
-  // adjacenty_data_.setup(mbi);
   vertex_data_.setup(mbi);
 }
 
@@ -28,7 +25,6 @@ MBDirectAccess::clear()
 {
   face_data_.clear();
   element_data_.clear();
-  adjacenty_data_.clear();
   vertex_data_.clear();
 }
 

--- a/src/moab/direct_access.cpp
+++ b/src/moab/direct_access.cpp
@@ -5,75 +5,31 @@
 
 #include "xdg/moab/direct_access.h"
 
-MBDirectAccess::MBDirectAccess(Interface* mbi) : mbi(mbi) { setup(); }
+MBDirectAccess::MBDirectAccess(Interface* mbi)
+: mbi(mbi)
+{
+  face_data_.entity_type = MBTRI;
+  element_data_.entity_type = MBTET;
+  adjacenty_data_.entity_type = MBTET;
+  setup();
+}
 
 void
 MBDirectAccess::setup() {
-  ErrorCode rval;
-
-  // setup triangles
-  Range tris;
-  rval = mbi->get_entities_by_dimension(0, 2, tris, true);
-  MB_CHK_SET_ERR_CONT(rval, "Failed to get all elements of dimension 2 (tris)");
-  num_elements_ = tris.size();
-
-  // only supporting triangle elements for now
-  if (!tris.all_of_type(MBTRI)) { throw std::runtime_error("Not all 2D elements are triangles"); }
-
-  moab::Range::iterator tris_it = tris.begin();
-  while(tris_it != tris.end()) {
-    // set connectivity pointer, element stride and the number of elements
-    EntityHandle* conntmp;
-    int n_elements;
-    rval = mbi->connect_iterate(tris_it, tris.end(), conntmp, element_stride_, n_elements);
-    MB_CHK_SET_ERR_CONT(rval, "Failed to get direct access to triangle elements");
-
-    // set const pointers for the connectivity array and add first element/length pair to the set of first elements
-    vconn_.push_back(conntmp);
-    first_elements_.push_back({*tris_it, n_elements});
-
-    // move iterator forward by the number of triangles in this contiguous memory block
-    tris_it += n_elements;
-  }
-
-  // setup vertices
-  Range verts;
-  rval = mbi->get_entities_by_dimension(0, 0, verts, true);
-  MB_CHK_SET_ERR_CONT(rval, "Failed to get all elements of dimension 0 (vertices)");
-  num_vertices_ = verts.size();
-
-  moab::Range::iterator verts_it = verts.begin();
-  while (verts_it != verts.end()) {
-    // set vertex coordinate pointers
-    double* xtmp;
-    double* ytmp;
-    double* ztmp;
-    int n_vertices;
-    rval = mbi->coords_iterate(verts_it, verts.end(), xtmp, ytmp, ztmp, n_vertices);
-    MB_CHK_SET_ERR_CONT(rval, "Failed to get direct access to vertex elements");
-
-    // add the vertex coordinate arrays to their corresponding vector of array pointers
-    tx_.push_back(&(*xtmp));
-    ty_.push_back(&(*ytmp));
-    tz_.push_back(&(*ztmp));
-
-    // move iterator forward by the number of vertices in this contiguous memory block
-    verts_it += n_vertices;
-  }
+  face_data_.setup(mbi);
+  element_data_.setup(mbi);
+  // TODO: fix adjacency setup for MOAB
+  // adjacenty_data_.setup(mbi);
+  vertex_data_.setup(mbi);
 }
 
 void
 MBDirectAccess::clear()
 {
-  num_elements_ = -1;
-  num_vertices_ = -1;
-  element_stride_ = -1;
-
-  first_elements_.clear();
-  vconn_.clear();
-  tx_.clear();
-  ty_.clear();
-  tz_.clear();
+  face_data_.clear();
+  element_data_.clear();
+  adjacenty_data_.clear();
+  vertex_data_.clear();
 }
 
 void


### PR DESCRIPTION
This refactors the direct access objects used to query MOAB face and element data so that elements and faces use the same data structure to reference vertex coordinates. IMO it makes the process of vertex coordinate lookups for these types easier to follow.

