### PR TITLE
Methods for efficiently returning the total number of volumetric elements in a mesh.

### DIFF
--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -83,6 +83,8 @@ public:
     return get_volume_elements(volume).size();
   }
 
+  int num_volume_elements() const override;
+
   int num_volume_faces(MeshID volume) const override {
     return mesh()->n_elem();
   }

--- a/include/xdg/mesh_manager_interface.h
+++ b/include/xdg/mesh_manager_interface.h
@@ -67,6 +67,8 @@ public:
   // Mesh
   virtual int num_volume_elements(MeshID volume) const = 0;
 
+  virtual int num_volume_elements() const;
+
   virtual int num_volume_faces(MeshID volume) const = 0;
 
   virtual int num_surface_faces(MeshID surface) const = 0;

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -53,6 +53,8 @@ public:
   // Mesh
   int num_volume_elements(MeshID volume) const override;
 
+  int num_volume_elements() const override;
+
   int num_volume_faces(MeshID volume) const override;
 
   int num_surface_faces(MeshID surface) const override;

--- a/src/libmesh/mesh_manager.cpp
+++ b/src/libmesh/mesh_manager.cpp
@@ -337,6 +337,12 @@ LibMeshManager::get_volume_elements(MeshID volume) const {
   return elements;
 }
 
+int
+LibMeshManager::num_volume_elements() const
+{
+  return mesh()->n_active_elem();
+}
+
 std::vector<MeshID>
 LibMeshManager::get_surface_faces(MeshID surface) const {
   return surface_map_.at(surface);

--- a/src/mesh_manager_interface.cpp
+++ b/src/mesh_manager_interface.cpp
@@ -54,6 +54,16 @@ MeshManager::volume_has_property(MeshID volume, PropertyType type) const
   return volume_metadata_.count({volume, type}) > 0;
 }
 
+int
+MeshManager::num_volume_elements() const
+{
+  int n_elements = 0;
+  for (auto volume : volumes()) {
+    n_elements += num_volume_elements(volume);
+  }
+  return n_elements;
+}
+
 std::vector<MeshID>
 MeshManager::get_volume_faces(MeshID volume) const
 {

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -168,6 +168,14 @@ MOABMeshManager::num_volume_elements(MeshID volume) const
 }
 
 int
+MOABMeshManager::num_volume_elements() const
+{
+  moab::Range elements;
+  this->moab_interface()->get_entities_by_dimension(this->root_set(), 3, elements);
+  return elements.size();
+}
+
+int
 MOABMeshManager::num_volume_faces(MeshID volume) const
 {
   int out {0};

--- a/tests/test_libmesh.cpp
+++ b/tests/test_libmesh.cpp
@@ -245,6 +245,7 @@ TEST_CASE("Test Volume Element Count Jezebel")
 
   auto elements = mesh_manager->get_volume_elements(volume);
   REQUIRE(elements.size() == 10333);
+  REQUIRE(mesh_manager->num_volume_elements() == 10333);
 }
 
 TEST_CASE("Test Point Location Jezebel")
@@ -282,6 +283,8 @@ TEST_CASE("Test Point Location Cylinder-Brick")
   mesh_manager->load_file("cyl-brick.exo");
   mesh_manager->init();
   xdg->prepare_raytracer();
+
+  REQUIRE(mesh_manager->num_volume_elements() == 16624);
 
   MeshID expected_volume = 1;
 
@@ -333,6 +336,8 @@ TEST_CASE("Test Find Element Brick")
   mesh_manager->load_file("brick.exo");
   mesh_manager->init();
   xdg->prepare_raytracer();
+
+  REQUIRE(mesh_manager->num_volume_elements() == 8790);
 
   MeshID volume = 1;
 

--- a/tests/test_mesh_internal.cpp
+++ b/tests/test_mesh_internal.cpp
@@ -18,6 +18,9 @@ TEST_CASE("Test Mesh Mock")
   REQUIRE(mm->num_volumes() == 1);
   REQUIRE(mm->num_surfaces() == 6);
   REQUIRE(mm->num_volume_faces(1) == 12);
+
+  REQUIRE(mm->num_volume_elements() == 12);
+  REQUIRE(mm->num_volume_elements(1) == 12);
 }
 
 TEST_CASE("Mesh Mock Get Surface Mesh")

--- a/tests/test_moab.cpp
+++ b/tests/test_moab.cpp
@@ -230,7 +230,10 @@ TEST_CASE("TEST MOAB Find Element Method")
   mesh_manager->init();
   xdg->prepare_raytracer();
 
+  REQUIRE(mesh_manager->num_volume_elements() == 10333);
+
   MeshID volume = 1;
+  REQUIRE(mesh_manager->num_volume_elements(1) == 10333);
 
   MeshID element = xdg->find_element(volume, {0.0, 0.0, 100.0});
   REQUIRE(element == ID_NONE); // should not find an element since the point is outside the volume


### PR DESCRIPTION
This adds the `MeshManagerInterface::num_volume_elements` method that returns the total number of volumetric elements in a mesh. This is useful for tally/source setup with using meshes in a particle transport code.

A default implementation based on `num_volume_elements(MeshID volume)` has been provided, but more efficient approaches exist for both MOAB and libMesh so I've applied those here.