### PR TITLE
Namespace direct access object

### DIFF
--- a/include/xdg/moab/direct_access.h
+++ b/include/xdg/moab/direct_access.h
@@ -10,7 +10,10 @@
 #include "xdg/constants.h"
 #include "xdg/vec3da.h"
 
+
 using namespace moab;
+
+namespace xdg {
 
 /*! Class to manage direct access of triangle connectivity and coordinates */
 class MBDirectAccess {
@@ -284,5 +287,7 @@ private:
   AdjacencyData element_adjacency_data_;
   VertexData vertex_data_;
 };
+
+} // namespace xdg
 
 #endif // include guard

--- a/src/moab/direct_access.cpp
+++ b/src/moab/direct_access.cpp
@@ -5,6 +5,8 @@
 
 #include "xdg/moab/direct_access.h"
 
+namespace xdg {
+
 MBDirectAccess::MBDirectAccess(Interface* mbi)
 : mbi(mbi)
 {
@@ -35,3 +37,5 @@ MBDirectAccess::update() {
   clear();
   setup();
 }
+
+} // namespace xdg


### PR DESCRIPTION
A very similar class with an identical name was created in https://github.com/pshriwise/double-down. This caused a symbol naming clash when building an executable that also links to DAGMC with double-down enabled. Adding the direct access class to the XDG namespace should prevent that in the future.