### PR TITLE
Simplify MOAB tag data retrieval

### DIFF
--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -114,12 +114,19 @@ public:
   }
 
   template<typename T>
-  std::vector<T> tag_data(moab::Tag tag, const std::vector<moab::EntityHandle>& entities) const {
+  std::vector<T> tag_data(moab::Tag tag, const std::vector<moab::EntityHandle>& entities, int length=1) const {
     if (entities.empty()) {
       return std::vector<T>();
     }
-    std::vector<T> data(entities.size());
+    std::vector<T> data(entities.size() * length);
     this->moab_interface()->tag_get_data(tag, entities.data(), entities.size(), data.data());
+    return data;
+  }
+
+  template<typename T>
+  std::vector<T> tag_data(moab::Tag tag, const moab::EntityHandle entity, int length) const {
+    std::vector<T> data(length);
+    this->moab_interface()->tag_get_data(tag, &entity, 1, data.data());
     return data;
   }
 

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -102,6 +102,40 @@ public:
   const std::shared_ptr<MBDirectAccess>& mb_direct() const { return mdam_; }
   moab::EntityHandle root_set() const { return 0; }
 
+  template<typename T>
+  std::vector<T> tag_data(moab::Tag tag, const moab::Range& entities) const {
+    if (entities.empty()) {
+      return std::vector<T>();
+    }
+    // ensure data container is sized appropriately
+    std::vector<T> data(entities.size());
+    this->moab_interface()->tag_get_data(tag, entities, data.data());
+    return data;
+  }
+
+  template<typename T>
+  std::vector<T> tag_data(moab::Tag tag, const std::vector<moab::EntityHandle>& entities) const {
+    if (entities.empty()) {
+      return std::vector<T>();
+    }
+    std::vector<T> data(entities.size());
+    this->moab_interface()->tag_get_data(tag, entities.data(), entities.size(), data.data());
+    return data;
+  }
+
+  template<typename T>
+  T tag_data(moab::Tag tag, const moab::EntityHandle entity) const {
+    T data;
+    this->moab_interface()->tag_get_data(tag, &entity, 1, &data);
+    return data;
+  }
+
+  std::string tag_data(moab::Tag tag, const moab::EntityHandle entity, int length) const {
+    std::string data(' ', length);
+    this->moab_interface()->tag_get_data(tag, &entity, 1, data.data());
+    return data;
+  }
+
 private:
   std::shared_ptr<moab::Interface> shared_moab_instance_;
   moab::Interface* moab_raw_ptr_;

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -224,10 +224,8 @@ std::array<Vertex, 3> MOABMeshManager::face_vertices(MeshID element) const
 std::pair<MeshID, MeshID>
 MOABMeshManager::surface_senses(MeshID surface) const
 {
-  std::array<moab::EntityHandle, 2> sense_data {0, 0};
   moab::EntityHandle surf_handle = surface_id_map_.at(surface);
-
-  this->moab_interface()->tag_get_data(surf_to_volume_sense_tag_, &surf_handle, 1, sense_data.data());
+  std::vector<moab::EntityHandle> sense_data = this->tag_data<moab::EntityHandle>(surf_to_volume_sense_tag_, surf_handle, 2);
 
   std::pair<MeshID, MeshID> mesh_ids {ID_NONE, ID_NONE};
   // independent calls in case one of the handles is invalid


### PR DESCRIPTION
This PR replaces direct calls to MOAB's `tag_get_data` methods. The primary motivation for this was the discovery in #143 that passing an empty to container to these methods results in a segfault within MOAB. Adding wrappers to perform a defensive check in a few places makes more sense than including them at a higher level, and at that point templating the methods also makes sense so we don't have a wrappers for each datatype we're gathering. There are a couple of methods that also enable us to get a single value for a single-handle query, which admittedly aren't necessary but it's quite convenient to be able to do:

```cpp
int dim = this->tag_data<int>(geometry_dimension_tag_, entity);
```

instead of 

```cpp 
int dim;
this->moab_interface()->tag_get_data(geometry_dimension_tag_, &entity, 1, &dim);
```

@Waqar-ukaea I know I know, I said I'd like to avoid over-templating, but I think it makes sense here I swear!

