### PR TITLE
libMesh updates

### DIFF
--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -329,6 +329,9 @@ public:
   //! based on their sense with respect to the surface triangles
   std::unordered_map<MeshID, std::pair<MeshID, MeshID>> surface_senses_;
 
+  int32_t num_elements_ {-1};
+
+  //! Mapping of surfaces to the volumes on either side. Volumes are ordered
   int32_t next_sidepair_id_ {1}; //!< Next available sidepair ID, starts at one
 };
 

--- a/src/libmesh/mesh_manager.cpp
+++ b/src/libmesh/mesh_manager.cpp
@@ -45,6 +45,8 @@ void LibMeshManager::init() {
     fatal_error("Mesh must be 3-dimensional");
   }
 
+  num_elements_ = mesh()->n_active_elem();
+
   auto libmesh_bounding_box = libMesh::MeshTools::create_bounding_box(*mesh());
 
   // identify all subdomain IDs in the mesh, these represent volumes
@@ -95,7 +97,9 @@ void LibMeshManager::init() {
 MeshID LibMeshManager::adjacent_element(MeshID element, int face) const {
   const auto elem_ptr = mesh()->elem_ptr(element);
   if (!elem_ptr) return ID_NONE;
-  return elem_ptr->neighbor_ptr(face)->id();
+  auto neighbor = elem_ptr->neighbor_ptr(face);
+  if (!neighbor) return ID_NONE;
+  return neighbor->id();
 }
 
 MeshID LibMeshManager::create_volume() {
@@ -340,7 +344,7 @@ LibMeshManager::get_volume_elements(MeshID volume) const {
 int
 LibMeshManager::num_volume_elements() const
 {
-  return mesh()->n_active_elem();
+  return num_elements_;
 }
 
 std::vector<MeshID>

--- a/tests/test_libmesh.cpp
+++ b/tests/test_libmesh.cpp
@@ -347,3 +347,25 @@ TEST_CASE("Test Find Element Brick")
   element = xdg->find_element(volume, {0.0, 0.0, 100.0});
   REQUIRE(element == ID_NONE);
 }
+
+TEST_CASE("Test Track Exiting Mesh Brick")
+{
+  std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::LIBMESH);
+  xdg->mesh_manager()->mesh_library();
+  REQUIRE(xdg->mesh_manager()->mesh_library() == MeshLibrary::LIBMESH);
+  const auto& mesh_manager = xdg->mesh_manager();
+  mesh_manager->load_file("brick.exo");
+  mesh_manager->init();
+  xdg->prepare_raytracer();
+
+  MeshID volume = 1;
+  Position start {0.0, 0.0, -1000.0};
+  Position end {0.0, 0.0, 1000.0};
+  auto tracks = xdg->segments(volume, start, end);
+
+  double length = std::accumulate(tracks.begin(), tracks.end(), 0.0, [](double sum, const auto& track) {
+    return sum + track.second;
+  });
+
+  REQUIRE_THAT(length, Catch::Matchers::WithinAbs(10.0, 1e-6));
+}


### PR DESCRIPTION
This PR

 - caches the total number of elements on the `LibMeshManager` instead of repeating the query each time
 - corrects behavior in the `LibMeshManager::adjacent_element` method
 - adds a test that exposes failure of the previous bullet by computing ray segments for a ray that extends far beyond the mesh bounds