### PR TITLE
Adding timers and tools for volumetric mesh tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 
 #===============================================================================
+# OpenMP
+#===============================================================================
+find_package(OpenMP REQUIRED)
+
+#===============================================================================
 # libMesh
 #===============================================================================
 if(XDG_ENABLE_LIBMESH)
@@ -105,6 +110,7 @@ src/util/str_utils.cpp
 src/tetrahedron_contain.cpp
 src/overlap_check/overlap.cpp
 src/element_face_accessor.cpp
+src/timer.cpp
 src/xdg.cpp
 )
 

--- a/include/xdg/timer.h
+++ b/include/xdg/timer.h
@@ -1,0 +1,51 @@
+#ifndef XDG_TIMER_H
+#define XDG_TIMER_H
+
+#include <chrono>
+
+namespace xdg {
+
+//==============================================================================
+// Global variables
+//==============================================================================
+
+class Timer;
+
+//==============================================================================
+//! Class for measuring time elapsed
+//==============================================================================
+
+class Timer {
+public:
+  using clock = std::chrono::high_resolution_clock;
+
+  Timer() {};
+
+  //! Start running the timer
+  void start();
+
+  //! Get total elapsed time in seconds
+  //! \return Elapsed time in [s]
+  double elapsed();
+
+  //! Stop running the timer
+  void stop();
+
+  //! Stop the timer and reset its elapsed time
+  void reset();
+
+private:
+  bool running_ {false};                 //!< is timer running?
+  std::chrono::time_point<clock> start_; //!< starting point for clock
+  double elapsed_ {0.0};                 //!< elapsed time in [s]
+};
+
+//==============================================================================
+// Non-member functions
+//==============================================================================
+
+void reset_timers();
+
+} // namespace xdg
+
+#endif // XDG_TIMER_H

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -1,0 +1,37 @@
+#include "xdg/timer.h"
+
+namespace xdg {
+
+//==============================================================================
+// Timer implementation
+//==============================================================================
+
+void Timer::start()
+{
+  running_ = true;
+  start_ = clock::now();
+}
+
+void Timer::stop()
+{
+  elapsed_ = elapsed();
+  running_ = false;
+}
+
+void Timer::reset()
+{
+  running_ = false;
+  elapsed_ = 0.0;
+}
+
+double Timer::elapsed()
+{
+  if (running_) {
+    std::chrono::duration<double> diff = clock::now() - start_;
+    return elapsed_ + diff.count();
+  } else {
+    return elapsed_;
+  }
+}
+
+} // namespace xdg

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -7,11 +7,13 @@ ray_fire
 find_volume
 point_in_volume
 overlap_check
+walk_elements
+tally_segments
 )
 
 foreach(tool ${TOOL_NAMES})
     string(REPLACE "_" "-" tool_exec ${tool})
     add_executable(${tool_exec} ${tool}.cpp)
-    target_link_libraries(${tool_exec} xdg argparse indicators::indicators)
+    target_link_libraries(${tool_exec} xdg argparse indicators::indicators OpenMP::OpenMP_CXX)
     install(TARGETS ${tool_exec} DESTINATION ${CMAKE_INSTALL_BINDIR}/tools)
 endforeach()

--- a/tools/tally_segments.cpp
+++ b/tools/tally_segments.cpp
@@ -1,0 +1,100 @@
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "xdg/error.h"
+#include "xdg/mesh_manager_interface.h"
+#include "xdg/vec3da.h"
+#include "xdg/xdg.h"
+
+#include "argparse/argparse.hpp"
+
+#include "tally_segments.h"
+
+using namespace xdg;
+
+int main(int argc, char** argv) {
+
+// argument parsing
+argparse::ArgumentParser args("XDG Mesh Tally Simulator", "1.0", argparse::default_arguments::help);
+
+args.add_argument("filename")
+    .help("Path to the input file");
+
+args.add_argument("-l", "--library")
+    .help("Mesh library to use. One of (MOAB, LIBMESH)")
+    .default_value("MOAB");
+
+args.add_argument("-n", "--num-tracks")
+    .help("Number of tracks to simulate")
+    .default_value(1000)
+    .scan<'i', int>();
+
+args.add_argument("-t", "--threads")
+    .help("Number of threads to use")
+    .default_value(-1)
+    .scan<'i', int>();
+
+args.add_argument("-v", "--verbose")
+    .default_value(false)
+    .implicit_value(true)
+    .help("Enable verbose output");
+
+args.add_argument("-q", "--quiet")
+    .default_value(false)
+    .implicit_value(true)
+    .help("Minimize all output (for performance testing)");
+
+args.add_argument("-c", "--check-tracks")
+    .help("Verify that track lengths always match the sum of segments")
+    .flag();
+
+  try {
+    args.parse_args(argc, argv);
+  }
+  catch (const std::runtime_error& err) {
+    std::cout << err.what() << std::endl;
+    std::cout << args;
+    exit(0);
+  }
+
+// Problem Setup
+srand48(42);
+
+// create a mesh manager
+std::shared_ptr<XDG> xdg {nullptr};
+if (args.get<std::string>("--library") == "MOAB")
+  xdg = XDG::create(MeshLibrary::MOAB);
+else if (args.get<std::string>("--library") == "LIBMESH")
+  xdg = XDG::create(MeshLibrary::LIBMESH);
+else
+  fatal_error("Invalid mesh library {} specified", args.get<std::string>("--library"));
+
+const auto& mm = xdg->mesh_manager();
+mm->load_file(args.get<std::string>("filename"));
+mm->init();
+mm->parse_metadata();
+xdg->prepare_raytracer();
+
+// get the bounding box of the mesh
+BoundingBox bbox = xdg->mesh_manager()->global_bounding_box();
+std::cout << fmt::format("Mesh Bounding Box: {}", bbox) << std::endl;
+
+bool check_tracks = args.get<bool>("--check-tracks");
+
+size_t n_tracks = args.get<int>("--num-tracks");
+
+TallyContext tally_context;
+tally_context.xdg_ = xdg;
+int n_threads = args.get<int>("--threads");
+if (n_threads >= 1) tally_context.n_threads_ = n_threads;
+tally_context.n_tracks_ = args.get<int>("--num-tracks");
+tally_context.check_tracks_ = args.get<bool>("--check-tracks");
+tally_context.verbose_ = args.get<bool>("--verbose");
+tally_context.quiet_ = args.get<bool>("--quiet");
+
+tally_segments(tally_context);
+
+return 0;
+
+}

--- a/tools/tally_segments.h
+++ b/tools/tally_segments.h
@@ -1,0 +1,87 @@
+#include <memory>
+#include <string>
+#include <vector>
+#include <numeric>
+#include <omp.h>
+
+#include <indicators/block_progress_bar.hpp>
+
+#include "xdg/error.h"
+#include "xdg/util/progress_bars.h"
+#include "xdg/vec3da.h"
+#include "xdg/timer.h"
+
+#include "xdg/xdg.h"
+
+
+using namespace xdg;
+
+struct TallyContext {
+  std::shared_ptr<XDG> xdg_;
+  int n_threads_ {1};
+  int n_tracks_ {0};
+  bool check_tracks_ {false};
+  bool verbose_ {false};
+  bool quiet_ {false};
+};
+
+Position sample_box_location(const BoundingBox& bbox) {
+  return bbox.lower_left() + bbox.width() * Vec3da(drand48(), drand48(), drand48());
+}
+
+void tally_segments(const TallyContext& context) {
+  const auto& xdg = context.xdg_;
+
+  // get the bounding box of the mesh
+  BoundingBox bbox = xdg->mesh_manager()->global_bounding_box();
+  std::cout << fmt::format("Mesh Bounding Box: {}", bbox) << "\n";
+
+  using namespace indicators;
+  auto prog_bar = block_progress_bar(fmt::format("Running {} tally tracks", context.n_tracks_));
+
+  omp_set_num_threads(context.n_threads_);
+  std::cout << fmt::format("Using {} threads", context.n_threads_) << "\n";
+
+  int n_tracks_run = 0;
+
+  Timer timer;
+  timer.start();
+  #pragma omp parallel shared(n_tracks_run)
+  {
+    #pragma omp for
+    for (int i = 0; i < context.n_tracks_; i++) {
+      // sample a location within the bounding box
+      Position r1 = sample_box_location(bbox);
+      if (!bbox.contains(r1)) fatal_error(fmt::format("Point {} is not within the mesh bounding box", r1));
+
+      Position r2 = sample_box_location(bbox);
+      if (!bbox.contains(r2)) fatal_error(fmt::format("Point {} is not within the mesh bounding box", r2));
+
+      auto segments = xdg->segments(r1, r2);
+      #pragma omp atomic
+      n_tracks_run++;
+
+      if (context.quiet_) continue;
+
+      if (context.verbose_) {
+          std::cout << fmt::format("Track {}: {} segments", i, segments.size()) << "\n";
+      } else {
+          prog_bar.set_progress(100.0 * (double)n_tracks_run / (double)context.n_tracks_);
+      }
+
+      if (context.check_tracks_) {
+        double track_length = (r2 - r1).length();
+        double segement_sum = std::accumulate(segments.begin(), segments.end(), 0.0, [](double v, const auto& s) { return v + s.second; });
+        double diff = fabs(track_length - segement_sum);
+        if (diff > TINY_BIT) {
+          fatal_error(fmt::format("Track length check failed.\n Start: {}\n End: {}\n Diff: {}", r1, r2, diff));
+        }
+      }
+    }
+  }
+  timer.stop();
+
+  if (!context.quiet_) prog_bar.mark_as_completed();
+
+  std::cout << fmt::format("Time elapsed: {} s", timer.elapsed()) << "\n";
+}

--- a/tools/walk_elements.cpp
+++ b/tools/walk_elements.cpp
@@ -1,0 +1,92 @@
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "xdg/error.h"
+#include "xdg/mesh_manager_interface.h"
+#include "xdg/vec3da.h"
+#include "xdg/xdg.h"
+
+#include "argparse/argparse.hpp"
+
+#include "walk_elements.h"
+
+using namespace xdg;
+
+int main(int argc, char** argv) {
+
+// argument parsing
+argparse::ArgumentParser args("XDG Volumetric Element Tracking Simulator", "1.0", argparse::default_arguments::help);
+
+args.add_argument("filename")
+    .help("Path to the input file");
+
+args.add_argument("-l", "--library")
+    .help("Mesh library to use. One of (MOAB, LIBMESH)")
+    .default_value("MOAB");
+
+args.add_argument("-n", "--num-particles")
+    .help("Number of particles to simulate")
+    .default_value(1000)
+    .scan<'i', int>();
+
+args.add_argument("-t", "--threads")
+    .help("Number of threads to use")
+    .default_value(-1)
+    .scan<'i', int>();
+
+args.add_argument("-v", "--verbose")
+    .default_value(false)
+    .implicit_value(true)
+    .help("Enable verbose output of particle events");
+
+args.add_argument("-q", "--quiet")
+    .default_value(false)
+    .implicit_value(true)
+    .help("Minimize all output (for performance testing)");
+
+args.add_argument("-m", "--mfp")
+    .default_value(1.0)
+    .help("Mean free path of the particles").scan<'g', double>();
+
+  try {
+    args.parse_args(argc, argv);
+  }
+  catch (const std::runtime_error& err) {
+    std::cout << err.what() << std::endl;
+    std::cout << args;
+    exit(0);
+  }
+
+// Problem Setup
+srand48(42);
+
+// create a mesh manager
+std::shared_ptr<XDG> xdg {nullptr};
+if (args.get<std::string>("--library") == "MOAB")
+  xdg = XDG::create(MeshLibrary::MOAB);
+else if (args.get<std::string>("--library") == "LIBMESH")
+  xdg = XDG::create(MeshLibrary::LIBMESH);
+else
+  fatal_error("Invalid mesh library {} specified", args.get<std::string>("--library"));
+
+const auto& mm = xdg->mesh_manager();
+mm->load_file(args.get<std::string>("filename"));
+mm->init();
+mm->parse_metadata();
+xdg->prepare_raytracer();
+
+WalkElementsContext walkelementscontext;
+
+walkelementscontext.xdg_ = xdg;
+int n_threads = args.get<int>("--threads");
+if (n_threads >= 1) walkelementscontext.n_threads_ = n_threads;
+walkelementscontext.n_particles_ = args.get<int>("--num-particles");
+walkelementscontext.mean_free_path_ = args.get<double>("--mfp");
+walkelementscontext.verbose_ = args.get<bool>("--verbose");
+walkelementscontext.quiet_ = args.get<bool>("--quiet");
+
+walk_elements(walkelementscontext);
+
+return 0;
+}

--- a/tools/walk_elements.h
+++ b/tools/walk_elements.h
@@ -1,0 +1,127 @@
+#include <memory>
+#include <string>
+#include <vector>
+#include <numeric>
+#include <omp.h>
+
+#include <indicators/block_progress_bar.hpp>
+
+#include "xdg/error.h"
+#include "xdg/util/progress_bars.h"
+#include "xdg/vec3da.h"
+#include "xdg/timer.h"
+
+#include "xdg/xdg.h"
+
+using namespace xdg;
+
+Position sample_box_location(const BoundingBox& bbox) {
+  return bbox.lower_left() + bbox.width() * Vec3da(drand48(), drand48(), drand48());
+}
+
+struct WalkElementsContext {
+  std::shared_ptr<XDG> xdg_;
+  int n_threads_ {1};
+  double mean_free_path_;
+  size_t n_particles_;
+  bool verbose_;
+  bool quiet_;
+};
+
+void walk_elements(const WalkElementsContext& context) {
+  auto xdg = context.xdg_;
+  double mean_free_path = context.mean_free_path_;
+
+  // get the bounding box of the mesh
+  BoundingBox bbox = xdg->mesh_manager()->global_bounding_box();
+  std::cout << fmt::format("Mesh Bounding Box: {}", bbox) << "\n";
+
+  double total_distance = 0.0;
+  auto prog_bar = block_progress_bar(fmt::format("Running {} particles", context.n_particles_));
+
+  int n_particles_run = 0;
+
+  omp_set_num_threads(context.n_threads_);
+  std::cout << fmt::format("Using {} threads", context.n_threads_) << "\n";
+
+  Timer timer;
+  timer.start();
+  #pragma omp parallel shared(n_particles_run)
+  {
+    // Each thread needs its own random number state
+    double thread_total_distance = 0.0;
+
+    #pragma omp for
+    for (int i = 0; i < context.n_particles_; i++) {
+      int n_events = 0;
+      double distance = 0.0;
+      MeshID element = ID_NONE;
+      Position r;
+
+      // sample a location within the model
+      while (element == ID_NONE) {
+        r = sample_box_location(bbox);
+        element = xdg->find_element(r);
+      }
+
+      Direction u = rand_dir();
+      u.normalize();
+      std::vector<MeshID> primitives;
+      while (element != ID_NONE) {
+        // determine the distace to the next element
+        auto [next_element, exit_distance] = xdg->next_element(element, r, u);
+
+        // determine the distance to the next collision
+        double collision_distance = -std::log(1.0 - drand48()) * mean_free_path;
+
+        if (collision_distance < exit_distance) {
+          r += u * collision_distance;
+          distance += collision_distance;
+          // simulate an isotropic collision
+          u = rand_dir();
+        } else {
+          r += u * exit_distance;
+          distance += exit_distance;
+          // if the next element isn't present, move on to the next particle
+          element = next_element;
+        }
+
+        // attempt to trace the mesh boundary for re-entrance
+        while (element == ID_NONE) {
+          auto ray_hit = xdg->ray_fire(xdg->mesh_manager()->implicit_complement(), r, u, INFTY, HitOrientation::EXITING, &primitives);
+          // if there is no re-entry point, move on to the next particle
+          if (ray_hit.second == ID_NONE) break;
+
+          // move ray up to surface
+          r += u * ray_hit.first;
+          distance += ray_hit.first;
+          // TODO: if we intersected a corner, we might not find an element
+          element = xdg->find_element(r+ u*TINY_BIT);
+        }
+        primitives.clear();
+        n_events++;
+      }
+      thread_total_distance += distance;
+      #pragma omp atomic
+      n_particles_run++;
+      if (context.quiet_) continue;
+      if (context.verbose_) {
+          std::cout << fmt::format("Particle {} underwent {} events. Distance: {}", i, n_events, distance) << "\n";
+      } else {
+          prog_bar.set_progress(100.0 * (double)n_particles_run / (double)context.n_particles_);
+      }
+    }
+
+    #pragma omp atomic
+    total_distance += thread_total_distance;
+  }
+  timer.stop();
+
+  if (!context.quiet_) prog_bar.mark_as_completed();
+
+  std::cout << fmt::format("Time elapsed: {} s", timer.elapsed()) << "\n";
+
+  if (context.verbose_ && !context.quiet_) {
+    std::cout << fmt::format("Average distance: {}", total_distance/context.n_particles_) << "\n";
+  }
+}


### PR DESCRIPTION
This adds a few items:

 - A timer object for tracking operation times (ray fires, element walking, etc).
 - A tool for walking the elements of a mesh, `walk-elements`. This is akin to particle transport on a volumetric mesh, including re-entrance checks when particles get to the mesh exterior/implicit complement.
 - A tool to mimic laying tally tracks onto a mesh object, `tally-segments`.