### PR TITLE
XDG Configuration Object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,8 @@ src/ray_tracing_interface.cpp
 src/triangle_intersect.cpp
 src/util/str_utils.cpp
 src/tetrahedron_contain.cpp
+src/config.cpp
+src/xdg.cpp
 src/overlap_check/overlap.cpp
 src/element_face_accessor.cpp
 src/xdg.cpp
@@ -173,6 +175,15 @@ endif()
 
 if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
   target_compile_definitions(xdg PUBLIC XDG_DEBUG)
+endif()
+
+target_link_libraries(xdg embree fmt::fmt)
+
+# attempt to find OpenMP and include it if found
+find_package(OpenMP)
+if (OpenMP_CXX_FOUND)
+  target_link_libraries(xdg OpenMP::OpenMP_CXX)
+  target_compile_definitions(xdg PUBLIC XDG_HAVE_OPENMP)
 endif()
 
 if (XDG_BUILD_TESTS)

--- a/include/xdg/config.h
+++ b/include/xdg/config.h
@@ -6,9 +6,13 @@
 #include <string>
 #include <unordered_map>
 
+#include "xdg/constants.h"
+
 #ifdef XDG_ENABLE_LIBMESH
 #include "libmesh/libmesh.h"
 #endif
+
+namespace xdg {
 
 class XDGConfig {
 public:
@@ -29,15 +33,22 @@ private:
   // Configuration options
   std::unordered_map<std::string, std::string> options_;
 
-  #ifdef XDG_ENABLE_LIBMESH
-  void initialize_libmesh();
+  void initialize_libraries();
 
+public:
+
+  bool ray_tracer_enabled(RTLibrary rt_lib) const;
+  bool mesh_manager_enabled(MeshLibrary mesh_lib) const;
+
+private:
+  #ifdef XDG_ENABLE_LIBMESH
   std::unique_ptr<libMesh::LibMeshInit> libmesh_init_ {nullptr};
   #endif
-
   // Data members
   int n_threads_ {-1};
   bool initialized_ {false};
 };
+
+} // namespace xdg
 
 #endif // XDG_CONFIG_H

--- a/include/xdg/config.h
+++ b/include/xdg/config.h
@@ -38,7 +38,6 @@ private:
   // Data members
   int n_threads_ {-1};
   bool initialized_ {false};
-
 };
 
 #endif // XDG_CONFIG_H

--- a/include/xdg/config.h
+++ b/include/xdg/config.h
@@ -1,0 +1,44 @@
+
+#ifndef XDG_CONFIG_H
+#define XDG_CONFIG_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#ifdef XDG_ENABLE_LIBMESH
+#include "libmesh/libmesh.h"
+#endif
+
+class XDGConfig {
+public:
+  // Get the singleton instance
+  static XDGConfig& config() {
+    static XDGConfig instance;
+    return instance;
+  }
+
+  // Delete copy constructor and assignment operator
+  XDGConfig(const XDGConfig&) = delete;
+  XDGConfig& operator=(const XDGConfig&) = delete;
+
+private:
+  // Private constructor
+  XDGConfig(int n_threads = -1);
+
+  // Configuration options
+  std::unordered_map<std::string, std::string> options_;
+
+  #ifdef XDG_ENABLE_LIBMESH
+  void initialize_libmesh();
+
+  std::unique_ptr<libMesh::LibMeshInit> libmesh_init_ {nullptr};
+  #endif
+
+  // Data members
+  int n_threads_ {-1};
+  bool initialized_ {false};
+
+};
+
+#endif // XDG_CONFIG_H

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -21,7 +21,6 @@ XDGConfig::XDGConfig(int n_threads) {
   #endif
   }
 
-
   // Initialize libMesh if enabled
   #ifdef XDG_ENABLE_LIBMESH
   initialize_libmesh();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -5,6 +5,8 @@
 #include "omp.h"
 #endif
 
+using namespace xdg;
+
 XDGConfig::XDGConfig(int n_threads) {
   // Set the number of threads
   if (n_threads != -1) {
@@ -22,19 +24,39 @@ XDGConfig::XDGConfig(int n_threads) {
   }
 
   // Initialize libMesh if enabled
-  #ifdef XDG_ENABLE_LIBMESH
-  initialize_libmesh();
-  #endif
+  initialize_libraries();
 
   initialized_ = true;
+
+  // set values for which mesh and ray tracing libraries are enabled
 }
 
+void XDGConfig::initialize_libraries() {
 #ifdef XDG_ENABLE_LIBMESH
-void XDGConfig::initialize_libmesh() {
   // libmesh requires the program name, so at least one argument is needed
   int argc = 1;
   const std::string argv{"XDG"};
   const char *argv_cstr = argv.c_str();
   libmesh_init_ = std::make_unique<libMesh::LibMeshInit>(argc, &argv_cstr, 0, n_threads_);
-}
 #endif
+}
+
+bool XDGConfig::ray_tracer_enabled(RTLibrary rt_lib) const {
+  #ifdef XDG_ENABLE_EMBREE
+  if (rt_lib == RTLibrary::EMBREE) return true;
+  #endif
+  #ifdef XDG_ENABLE_GPRT
+  if (rt_lib == RTLibrary::GPRT) return true;
+  #endif
+  return false;
+}
+
+bool XDGConfig::mesh_manager_enabled(MeshLibrary mesh_lib) const {
+  #ifdef XDG_ENABLE_MOAB
+  if (mesh_lib == MeshLibrary::MOAB) return true;
+  #endif
+  #ifdef XDG_ENABLE_LIBMESH
+  if (mesh_lib == MeshLibrary::LIBMESH) return true;
+  #endif
+  return false;
+}

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,41 @@
+
+#include "xdg/config.h"
+
+#ifdef XDG_HAVE_OPENMP
+#include "omp.h"
+#endif
+
+XDGConfig::XDGConfig(int n_threads) {
+  // Set the number of threads
+  if (n_threads != -1) {
+    n_threads_ = n_threads;
+  }
+
+  // if threads aren't manually specified,
+  // set using OpenMP
+  if (n_threads_ == -1) {
+  #ifdef XDG_HAVE_OPENMP
+    n_threads_ = omp_get_num_threads();
+  #else
+    n_threads_ = 1;
+  #endif
+  }
+
+
+  // Initialize libMesh if enabled
+  #ifdef XDG_ENABLE_LIBMESH
+  initialize_libmesh();
+  #endif
+
+  initialized_ = true;
+}
+
+#ifdef XDG_ENABLE_LIBMESH
+void XDGConfig::initialize_libmesh() {
+  // libmesh requires the program name, so at least one argument is needed
+  int argc = 1;
+  const std::string argv{"XDG"};
+  const char *argv_cstr = argv.c_str();
+  libmesh_init_ = std::make_unique<libMesh::LibMeshInit>(argc, &argv_cstr, 0, n_threads_);
+}
+#endif

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -25,10 +25,6 @@ XDGConfig::XDGConfig(int n_threads) {
 
   // Initialize libMesh if enabled
   initialize_libraries();
-
-  initialized_ = true;
-
-  // set values for which mesh and ray tracing libraries are enabled
 }
 
 void XDGConfig::initialize_libraries() {
@@ -39,6 +35,8 @@ void XDGConfig::initialize_libraries() {
   const char *argv_cstr = argv.c_str();
   libmesh_init_ = std::make_unique<libMesh::LibMeshInit>(argc, &argv_cstr, 0, n_threads_);
 #endif
+
+  initialized_ = true;
 }
 
 bool XDGConfig::ray_tracer_enabled(RTLibrary rt_lib) const {

--- a/tests/test_overlap_check.cpp
+++ b/tests/test_overlap_check.cpp
@@ -5,13 +5,25 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#ifdef XDG_HAVE_OPENMP
+#include <omp.h>
+#endif
+
 // xdg includes
 #include "xdg/error.h"
 #include "xdg/overlap.h"
 
 using namespace xdg;
 
-TEST_CASE("Overlapping Volumes Test")
+struct OMP_SingleThreadFixture {
+    OMP_SingleThreadFixture() {
+      #ifdef XDG_HAVE_OPENMP
+        omp_set_num_threads(1);
+      #endif
+    }
+};
+
+TEST_CASE_METHOD(OMP_SingleThreadFixture, "Overlapping Volumes Test", "[single-thread]")
 {
   // Create a mesh manager
   std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
@@ -32,7 +44,7 @@ TEST_CASE("Overlapping Volumes Test")
   REQUIRE(expected_overlaps == overlap_map.begin()->first);
 }
 
-TEST_CASE("Non-Overlapping Volumes Test")
+TEST_CASE_METHOD(OMP_SingleThreadFixture, "Non-Overlapping Volumes Test", "[single-thread]")
 {
   // Create a mesh manager
   std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
@@ -49,7 +61,7 @@ TEST_CASE("Non-Overlapping Volumes Test")
   REQUIRE(overlap_map.size() == 0);
 }
 
-TEST_CASE("Non-Overlapping Imprinted Volumes Test")
+TEST_CASE_METHOD(OMP_SingleThreadFixture, "Non-Overlapping Imprinted Volumes Test", "[single-thread]")
 {
   // Create a mesh manager
   std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
@@ -66,7 +78,7 @@ TEST_CASE("Non-Overlapping Imprinted Volumes Test")
   REQUIRE(overlap_map.size() == 0);
 }
 
-TEST_CASE("Enclosed Volume Test")
+TEST_CASE_METHOD(OMP_SingleThreadFixture, "Enclosed Volume Test", "[single-thread]")
 {
   // Create a mesh manager
   std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
@@ -87,7 +99,7 @@ TEST_CASE("Enclosed Volume Test")
   REQUIRE(expected_overlaps == overlap_map.begin()->first);
 }
 
-TEST_CASE("Small Overlap Test")
+TEST_CASE_METHOD(OMP_SingleThreadFixture, "Small Overlap Test", "[single-thread]")
 {
   // Create a mesh manager
   std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
@@ -108,7 +120,7 @@ TEST_CASE("Small Overlap Test")
   REQUIRE(expected_overlaps == overlap_map.begin()->first);
 }
 
-TEST_CASE("Small Edge Overlap Test")
+TEST_CASE_METHOD(OMP_SingleThreadFixture, "Small Edge Overlap Test", "[single-thread]")
 {
   // Create a mesh manager
   std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);
@@ -140,7 +152,7 @@ TEST_CASE("Small Edge Overlap Test")
   }
 }
 
-TEST_CASE("Beam Edge Overlap Test")
+TEST_CASE_METHOD(OMP_SingleThreadFixture, "Beam Edge Overlap Test", "[single-thread]")
 {
   // Create a mesh manager
   std::shared_ptr<XDG> xdg = XDG::create(MeshLibrary::MOAB);


### PR DESCRIPTION
This adds `XDGConfig` with a singleton method `XDGConfig::config()` that allows one to set library parameters and perform runtime checks for what is enabled in the current XDG build. 

This object will also handle forwarding of parameters to library initialization as needed. Currently, this aids in setting the number of threads in the libMesh initialization -- needed primarily because libMesh will set the number of threads to zero by default, even when using an OpenMP threading model.